### PR TITLE
Add one more missing `@Nullable` annotation to `Formatter`.

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -2610,7 +2610,7 @@ public final class Formatter implements Closeable, Flushable {
      * @return  This formatter
      */
     
-    public Formatter format(String format, Object ... args) {
+    public Formatter format(String format, @Nullable Object ... args) {
         return format(l, format, args);
     }
 


### PR DESCRIPTION
I noticed this when putting together
https://github.com/eisop/jdk/pull/29.
