### PR TITLE
Annotate the parameter of `Stream.ofNullable` as `@Nullable`.

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1176,7 +1176,7 @@ public interface Stream<T extends @Nullable Object> extends BaseStream<T, Stream
      *         is non-null, otherwise an empty stream
      * @since 9
      */
-    public static<T extends @Nullable Object> Stream<T> ofNullable(T t) {
+    public static<T extends @Nullable Object> Stream<T> ofNullable(@Nullable T t) {
         return t == null ? Stream.empty()
                          : StreamSupport.stream(new Streams.StreamBuilderImpl<>(t), false);
     }


### PR DESCRIPTION
I could see an argument for doing further work to declare the _type
parameter bound_ as _non_-`@Nullable`: The method can't be used to
create a `Stream` that ever contains `null`, so it would make some sense
to let it create only a `Stream<@NonNull Foo>`. Part of the question in
my mind is whether it would be good or bad for us to push users who have
a `Stream<E>` to write `Stream<@NonNull E>` if `E` is declared as `<E
extends @Nullable Object>`.

I don't know exactly what I think, so I'd like to at least land the
parameter change. If you have a preference for the type parameter, I can
make that change here and in a subsequent eisop PR.
