### PR TITLE
Make type arguments to `Class` and `Optional` non-nullable.

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -25,6 +25,7 @@
 
 package java.util;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -3079,7 +3080,7 @@ public class Collections {
      * @since 1.5
      */
     public static <E extends @Nullable Object> Collection<E> checkedCollection(Collection<E> c,
-                                                      Class<E> type) {
+                                                      Class<@NonNull E> type) {
         return new CheckedCollection<>(c, type);
     }
 
@@ -3236,7 +3237,7 @@ public class Collections {
      * @return a dynamically typesafe view of the specified queue
      * @since 1.8
      */
-    public static <E extends @Nullable Object> Queue<E> checkedQueue(Queue<E> queue, Class<E> type) {
+    public static <E extends @Nullable Object> Queue<E> checkedQueue(Queue<E> queue, Class<@NonNull E> type) {
         return new CheckedQueue<>(queue, type);
     }
 
@@ -3291,7 +3292,7 @@ public class Collections {
      * @return a dynamically typesafe view of the specified set
      * @since 1.5
      */
-    public static <E extends @Nullable Object> Set<E> checkedSet(Set<E> s, Class<E> type) {
+    public static <E extends @Nullable Object> Set<E> checkedSet(Set<E> s, Class<@NonNull E> type) {
         return new CheckedSet<>(s, type);
     }
 
@@ -3338,7 +3339,7 @@ public class Collections {
      * @since 1.5
      */
     public static <E extends @Nullable Object> SortedSet<E> checkedSortedSet(SortedSet<E> s,
-                                                    Class<E> type) {
+                                                    Class<@NonNull E> type) {
         return new CheckedSortedSet<>(s, type);
     }
 
@@ -3401,7 +3402,7 @@ public class Collections {
      * @since 1.8
      */
     public static <E extends @Nullable Object> NavigableSet<E> checkedNavigableSet(NavigableSet<E> s,
-                                                    Class<E> type) {
+                                                    Class<@NonNull E> type) {
         return new CheckedNavigableSet<>(s, type);
     }
 
@@ -3481,7 +3482,7 @@ public class Collections {
      * @return a dynamically typesafe view of the specified list
      * @since 1.5
      */
-    public static <E extends @Nullable Object> List<E> checkedList(List<E> list, Class<E> type) {
+    public static <E extends @Nullable Object> List<E> checkedList(List<E> list, Class<@NonNull E> type) {
         return (list instanceof RandomAccess ?
                 new CheckedRandomAccessList<>(list, type) :
                 new CheckedList<>(list, type));
@@ -3628,8 +3629,8 @@ public class Collections {
      * @since 1.5
      */
     public static <K extends @Nullable Object, V extends @Nullable Object> Map<K, V> checkedMap(Map<K, V> m,
-                                              Class<K> keyType,
-                                              Class<V> valueType) {
+                                              Class<@NonNull K> keyType,
+                                              Class<@NonNull V> valueType) {
         return new CheckedMap<>(m, keyType, valueType);
     }
 
@@ -4038,8 +4039,8 @@ public class Collections {
      * @since 1.5
      */
     public static <K extends @Nullable Object,V extends @Nullable Object> SortedMap<K,V> checkedSortedMap(SortedMap<K, V> m,
-                                                        Class<K> keyType,
-                                                        Class<V> valueType) {
+                                                        Class<@NonNull K> keyType,
+                                                        Class<@NonNull V> valueType) {
         return new CheckedSortedMap<>(m, keyType, valueType);
     }
 
@@ -4115,8 +4116,8 @@ public class Collections {
      * @since 1.8
      */
     public static <K extends @Nullable Object,V extends @Nullable Object> NavigableMap<K,V> checkedNavigableMap(NavigableMap<K, V> m,
-                                                        Class<K> keyType,
-                                                        Class<V> valueType) {
+                                                        Class<@NonNull K> keyType,
+                                                        Class<@NonNull V> valueType) {
         return new CheckedNavigableMap<>(m, keyType, valueType);
     }
 

--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -391,7 +391,7 @@ import jdk.internal.reflect.Reflection;
  */
 
 @NullMarked
-public final  class ServiceLoader<S extends @Nullable Object>
+public final  class ServiceLoader<S>
     implements Iterable<S>
 {
     // The class or interface representing the service being loaded
@@ -440,7 +440,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * @since 9
      * @spec JPMS
      */
-    public static interface Provider<S extends @Nullable Object> extends Supplier<S> {
+    public static interface Provider<S> extends Supplier<S> {
         /**
          * Returns the provider type. There is no guarantee that this type is
          * accessible or that it has a public no-args constructor. The {@link
@@ -683,7 +683,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * permissions, the static factory to obtain the provider or the
      * provider's no-arg constructor.
      */
-    private static class ProviderImpl<S extends @Nullable Object> implements Provider<S> {
+    private static class ProviderImpl<S> implements Provider<S> {
         final Class<S> service;
         final Class<? extends S> type;
         final Method factoryMethod;  // factory method or null
@@ -907,7 +907,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * Implements lazy service provider lookup of service providers that
      * are provided by modules in a module layer (or parent layers)
      */
-    private final class LayerLookupIterator<T extends @Nullable Object>
+    private final class LayerLookupIterator<T>
         implements Iterator<Provider<T>>
     {
         Deque<ModuleLayer> stack = new ArrayDeque<>();
@@ -984,7 +984,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * are provided by modules defined to a class loader or to modules in
      * layers with a module defined to the class loader.
      */
-    private final class ModuleServicesLookupIterator<T extends @Nullable Object>
+    private final class ModuleServicesLookupIterator<T>
         implements Iterator<Provider<T>>
     {
         ClassLoader currentLoader;
@@ -1109,7 +1109,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * configured via service configuration files. Service providers in named
      * modules are silently ignored by this lookup iterator.
      */
-    private final class LazyClassPathLookupIterator<T extends @Nullable Object>
+    private final class LazyClassPathLookupIterator<T>
         implements Iterator<Provider<T>>
     {
         static final String PREFIX = "META-INF/services/";
@@ -1463,7 +1463,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
         return StreamSupport.stream(s, false);
     }
 
-    private class ProviderSpliterator<T extends @Nullable Object> implements Spliterator<Provider<T>> {
+    private class ProviderSpliterator<T> implements Spliterator<Provider<T>> {
         final int expectedReloadCount = ServiceLoader.this.reloadCount;
         final Iterator<Provider<T>> iterator;
         int index;
@@ -1534,7 +1534,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      *
      * @return A new service loader
      */
-    static <S extends @Nullable Object> ServiceLoader<S> load(Class<S> service,
+    static <S> ServiceLoader<S> load(Class<S> service,
                                      ClassLoader loader,
                                      Module callerModule)
     {
@@ -1645,7 +1645,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * @spec JPMS
      */
     @CallerSensitive
-    public static <S extends @Nullable Object> ServiceLoader<S> load(Class<S> service,
+    public static <S> ServiceLoader<S> load(Class<S> service,
                                             @Nullable ClassLoader loader)
     {
         return new ServiceLoader<>(Reflection.getCallerClass(), service, loader);
@@ -1691,7 +1691,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * @spec JPMS
      */
     @CallerSensitive
-    public static <S extends @Nullable Object> ServiceLoader<S> load(Class<S> service) {
+    public static <S> ServiceLoader<S> load(Class<S> service) {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         return new ServiceLoader<>(Reflection.getCallerClass(), service, cl);
     }
@@ -1727,7 +1727,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * @spec JPMS
      */
     @CallerSensitive
-    public static <S extends @Nullable Object> ServiceLoader<S> loadInstalled(Class<S> service) {
+    public static <S> ServiceLoader<S> loadInstalled(Class<S> service) {
         ClassLoader cl = ClassLoader.getPlatformClassLoader();
         return new ServiceLoader<>(Reflection.getCallerClass(), service, cl);
     }
@@ -1780,7 +1780,7 @@ public final  class ServiceLoader<S extends @Nullable Object>
      * @spec JPMS
      */
     @CallerSensitive
-    public static <S extends @Nullable Object> ServiceLoader<S> load(ModuleLayer layer, Class<S> service) {
+    public static <S> ServiceLoader<S> load(ModuleLayer layer, Class<S> service) {
         return new ServiceLoader<>(Reflection.getCallerClass(), layer, service);
     }
 

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -637,7 +637,7 @@ public final class Collectors {
      * @param comparator a {@code Comparator} for comparing elements
      * @return a {@code Collector} that produces the minimal value
      */
-    public static <T extends @Nullable Object> Collector<T, ?, Optional<T>>
+    public static <T> Collector<T, ?, Optional<T>>
     minBy(Comparator<? super T> comparator) {
         return reducing(BinaryOperator.minBy(comparator));
     }
@@ -656,7 +656,7 @@ public final class Collectors {
      * @param comparator a {@code Comparator} for comparing elements
      * @return a {@code Collector} that produces the maximal value
      */
-    public static <T extends @Nullable Object> Collector<T, ?, Optional<T>>
+    public static <T> Collector<T, ?, Optional<T>>
     maxBy(Comparator<? super T> comparator) {
         return reducing(BinaryOperator.maxBy(comparator));
     }
@@ -910,7 +910,7 @@ public final class Collectors {
      * @see #reducing(Object, BinaryOperator)
      * @see #reducing(Object, Function, BinaryOperator)
      */
-    public static <T extends @Nullable Object> Collector<T, ?, Optional<T>>
+    public static <T> Collector<T, ?, Optional<T>>
     reducing(BinaryOperator<T> op) {
         class OptionalBox implements Consumer<T> {
             T value = null;

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -24,6 +24,7 @@
  */
 package java.util.stream;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -800,7 +801,7 @@ public interface Stream<T extends @Nullable Object> extends BaseStream<T, Stream
      * @see #min(Comparator)
      * @see #max(Comparator)
      */
-    Optional<T> reduce(BinaryOperator<T> accumulator);
+    Optional<@NonNull T> reduce(BinaryOperator<T> accumulator);
 
     /**
      * Performs a <a href="package-summary.html#Reduction">reduction</a> on the
@@ -980,7 +981,7 @@ public interface Stream<T extends @Nullable Object> extends BaseStream<T, Stream
      * or an empty {@code Optional} if the stream is empty
      * @throws NullPointerException if the minimum element is null
      */
-    Optional<T> min(Comparator<? super T> comparator);
+    Optional<@NonNull T> min(Comparator<? super T> comparator);
 
     /**
      * Returns the maximum element of this stream according to the provided
@@ -997,7 +998,7 @@ public interface Stream<T extends @Nullable Object> extends BaseStream<T, Stream
      * or an empty {@code Optional} if the stream is empty
      * @throws NullPointerException if the maximum element is null
      */
-    Optional<T> max(Comparator<? super T> comparator);
+    Optional<@NonNull T> max(Comparator<? super T> comparator);
 
     /**
      * Returns the count of elements in this stream.  This is a special case of
@@ -1111,7 +1112,7 @@ public interface Stream<T extends @Nullable Object> extends BaseStream<T, Stream
      * or an empty {@code Optional} if the stream is empty
      * @throws NullPointerException if the element selected is null
      */
-    Optional<T> findFirst();
+    Optional<@NonNull T> findFirst();
 
     /**
      * Returns an {@link Optional} describing some element of the stream, or an
@@ -1131,7 +1132,7 @@ public interface Stream<T extends @Nullable Object> extends BaseStream<T, Stream
      * @throws NullPointerException if the element selected is null
      * @see #findFirst()
      */
-    Optional<T> findAny();
+    Optional<@NonNull T> findAny();
 
     // Static factories
 


### PR DESCRIPTION
We've declared those classes' type parameters as having a bound of
`@NonNull Object`, as discussed in
https://github.com/jspecify/jspecify/issues/78. This PR changes type
arguments inside the JDK to be inside that bound.

eisop and typetools, by contrast, use a bound of `@Nullable Object`,
which they "undo" with `@NonNull T` on methods like `Class.newInstance`.
Thus, they don't need or want a change like this one. (That said, they
don't _universally_ use `@Nullable Object` as the bound in "cases like
this," so it's possible that they'd feel that a particular API, maybe
`ServiceLoader`, would be simpler with a non-nullable bound. Or, if not,
they may wish to use `@NonNull S` at the use sites.)

(The complicated API in this PR is `ServiceLoader`. I do see some docs
that suggest that `ServiceLoader` rejects any attempt to return a `null`
service instance, and that appears to be backed up by the implementation
I traced through to `ProviderImpl.get`.)
