### PR TITLE
Allow a `@Nullable` value for the second parameter of `requireNonNullElse`.

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -319,7 +319,7 @@ public final  class Objects {
      *        {@code defaultObj} is {@code null}
      * @since 9
      */
-    public static <T>  T requireNonNullElse(@Nullable T obj,  T defaultObj) {
+    public static <T>  T requireNonNullElse(@Nullable T obj,  @Nullable T defaultObj) {
         return (obj != null) ? obj : requireNonNull(defaultObj, "defaultObj");
     }
 


### PR DESCRIPTION
The existing approach follows the Checker Framework philosophy, under
which passing `null` for a `@Nullable` parameter should never lead to a
`NullPointerException`. (Compare `Method.invoke`, whose "receiver" _and_
"arguments" parameters are declared as non-nullable by the Checker
Framework, even though some callers _can_ pass `null` for the "receiver"
and some _must_ pass `null` for some of the arguments.)

The JSpecify thinking has moved in the direction of saying that, if
`null` should ever be permitted for a parameter, then the parameter
should be declared with a type that includes `null`. And we know that
many callers pass `null` for the second parameter. Here's an imaginary
such caller:

```java
for (Key key : union(map1.keySet(), map2.keySet()) {
  Value value = requireNonNullElse(map1.get(key), map2.get(key));
}
```

(We could consider making a similar change to `requireNonNullElseGet`.
But it's rarely used, and perhaps no one wants to pass a `Supplier` that
may return `null`, anyway. So I'm happy to leave it alone for now or to
change it if that's more palatable.)
