### PR TITLE
Annotate the parameter of `List.sort` as `@Nullable`.

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -1767,7 +1767,7 @@ public class ArrayList<E extends @Nullable Object> extends AbstractList<E>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void sort(Comparator<? super E> c) {
+    public void sort(@Nullable Comparator<? super E> c) {
         final int expectedModCount = modCount;
         Arrays.sort((E[]) elementData, 0, size, c);
         if (modCount != expectedModCount)

--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -514,7 +514,7 @@ public interface List<E extends @Nullable Object> extends Collection<E> {
      * @since 1.8
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    default void sort(Comparator<? super E> c) {
+    default void sort(@Nullable Comparator<? super E> c) {
         Object[] a = this.toArray();
         Arrays.sort(a, (Comparator) c);
         ListIterator<E> i = this.listIterator();

--- a/src/java.base/share/classes/java/util/Vector.java
+++ b/src/java.base/share/classes/java/util/Vector.java
@@ -1431,7 +1431,7 @@ public class Vector<E extends @Nullable Object>
 
     @SuppressWarnings("unchecked")
     @Override
-    public synchronized void sort(Comparator<? super E> c) {
+    public synchronized void sort(@Nullable Comparator<? super E> c) {
         final int expectedModCount = modCount;
         Arrays.sort((E[]) elementData, 0, elementCount, c);
         if (modCount != expectedModCount)

--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
@@ -885,7 +885,7 @@ public class CopyOnWriteArrayList<E extends @Nullable Object>
         setArray(es);
     }
 
-    public void sort(Comparator<? super E> c) {
+    public void sort(@Nullable Comparator<? super E> c) {
         synchronized (lock) {
             sortRange(c, 0, getArray().length);
         }


### PR DESCRIPTION
This has always struck me as a weird feature, but people use it, and it
"works" in the sense of "does not cause NPE" (though it may cause
CCE...). I see both calls to `sort(null)` and calls like
`sort(priorityQueue.comparator())` (which _might_ be `null`;
[example](https://github.com/google/guava/blob/e82e2a2c07c68108f318958ee0355cc835c97743/guava-testlib/src/com/google/common/collect/testing/testers/SortedSetNavigationTester.java#L57)).
And while I prefer a world in which methods like `comparator()` never
return `null`, as we arranged for [in
`SortedMultiset`](https://guava.dev/SortedMultiset#comparator()), there
are apparently [downsides](https://github.com/google/guava/issues/6187)
to using a `Comparator` that implements natural order rather than using
`null`.

Is any of that convincing? :) This is definitely a case in which I can
see how eisop would want to stay on its own path. My main motivation for
doing this now is that I hear that the current signature is causing us
trouble during Java->Kotlin transpilation. I can get more details.
