### PR TITLE
Annotate `PrintWriter.out` as `@Nullable`.

### DIFF
--- a/src/java.base/share/classes/java/io/PrintWriter.java
+++ b/src/java.base/share/classes/java/io/PrintWriter.java
@@ -70,7 +70,7 @@ public class PrintWriter extends Writer {
      *
      * @since 1.2
      */
-    protected Writer out;
+    protected @Nullable Writer out;
 
     private final boolean autoFlush;
     private boolean trouble = false;


### PR DESCRIPTION
The class appears to have zero documentation about what happens to this
field, unless you count that `close()` ["releases any system resources
associated with
it"](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/io/PrintWriter.html#close())
(and I note that that Javadoc, while it appears in `PrintWriter.java`,
is exactly the same as the more general Javadoc on `Closeable`).

But our J2KT folks noticed that they need to make the field `@Nullable`
so that their implementation (which I assume is meant to be
behavior-compatible with the JDK implementation) works under Kotlin.
That implementation (like the JDK's) assigns `null` to the field during
`close()`. That's easy to observe:

```java
import java.io.ByteArrayOutputStream;
import java.io.PrintWriter;

class PrintWriterOut extends PrintWriter {
  public static void main(String[] args) {
    var writer = new PrintWriterOut();
    writer.close();
    writer.showOut();
  }

  PrintWriterOut() {
    super(new ByteArrayOutputStream());
  }

  void showOut() {
    System.out.println(out);
  }
}
```

I see only a handful of reads from the field in Google's codebase (and
no writes, even though it's mutable!). They all look safe at the moment,
but it's easy to imagine a static analyzer that would suggest calling
`close()` on the stream, at which point they code would begin to NPE.

This is a tricky case for the Checker Framework philosophy, given that
users could both read and write the field: Should it be `@Nullable` (to
protect the more common use case, readers) or non-null (to prevent
anyone from writing `null` to the field)? I would probably lean
`@Nullable`, not just because reads are more common but also because
assigning `null` to the field doesn't typically lead to NPE, "only" to
silently marking the stream as closed... without closing any actual
backing stream that it might have.

(There's an additional layer of bug-prone-ness, which is that access to
`out` should be performed only when holding the stream's monitor. But
locking concerns are out of scope here.)
