### PR TITLE
Improve annotations in `PriorityBlockingQueue`.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
@@ -226,7 +226,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
      *         than 1
      */
     public PriorityBlockingQueue(int initialCapacity,
-                                 Comparator<? super E> comparator) {
+                                 @Nullable Comparator<? super E> comparator) {
         if (initialCapacity < 1)
             throw new IllegalArgumentException();
         this.comparator = comparator;
@@ -588,7 +588,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
      *         or {@code null} if this queue uses the natural
      *         ordering of its elements
      */
-    public Comparator<? super E> comparator() {
+    public @Nullable Comparator<? super E> comparator() {
         return comparator;
     }
 
@@ -782,7 +782,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
      *
      * @return an array containing all of the elements in this queue
      */
-    public @Nullable Object[] toArray() {
+    public Object[] toArray() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {


### PR DESCRIPTION
- Make the constructor's comparator parameter nullable.
- Make the comparator accessor's return type nullable.
- Express that `toArray()` never contains nulls.

Compare the similar work for `PriorityQueue` in
https://github.com/jspecify/jdk/pull/17
