### PR TITLE
Allow `Node.setNodeValue` to be called with a null argument.

### DIFF
--- a/src/java.xml/share/classes/org/w3c/dom/Node.java
+++ b/src/java.xml/share/classes/org/w3c/dom/Node.java
@@ -248,7 +248,7 @@ public interface Node {
      *   NO_MODIFICATION_ALLOWED_ERR: Raised when the node is readonly and if
      *   it is not defined to be <code>null</code>.
      */
-    public void setNodeValue(String nodeValue)
+    public void setNodeValue(@Nullable String nodeValue)
                               throws DOMException;
 
     /**


### PR DESCRIPTION
The specification is a bit unclear, but it  seems to imply that null is OK. The implementation also behaves that way. Also, having `getNodeValue` return `@Nullable String` but `setNodeValue` take just `String` means that Kotlin doesn't recognize them as a get/set pair so you can't write `node.nodeValue = whatever`.