### PR TITLE
Fix annotation on qualified type.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -1991,7 +1991,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
      * @throws ClassCastException {@inheritDoc}
      * @throws NullPointerException if the specified key is null
      */
-    public @Nullable Map.Entry<K,V> floorEntry(K key) {
+    public Map.@Nullable Entry<K,V> floorEntry(K key) {
         return findNearEntry(key, LT|EQ, comparator);
     }
 


### PR DESCRIPTION
This was noticed by @wmdietl in
https://github.com/eisop/jdk/pull/51#discussion_r1268297050

It is the only hit for...

```
git grep '@Nullable Map[.]'
```

...across the jspecify and eisop `jdk` repos.
