### PR TITLE
Annotate `AtomicReferenceFieldUpdater`.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.java
@@ -37,6 +37,8 @@ package java.util.concurrent.atomic;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -92,7 +94,8 @@ import java.lang.invoke.VarHandle;
  * @param <V> The type of the field
  */
 @AnnotatedFor({"interning"})
-public abstract @UsesObjectEquals class AtomicReferenceFieldUpdater<T,V> {
+@NullMarked
+public abstract @UsesObjectEquals class AtomicReferenceFieldUpdater<T,V extends @Nullable Object> {
 
     /**
      * Creates and returns an updater for objects with the given field.
@@ -113,8 +116,8 @@ public abstract @UsesObjectEquals class AtomicReferenceFieldUpdater<T,V> {
      * access control
      */
     @CallerSensitive
-    public static <U,W> AtomicReferenceFieldUpdater<U,W> newUpdater(Class<U> tclass,
-                                                                    Class<W> vclass,
+    public static <U,W extends @Nullable Object> AtomicReferenceFieldUpdater<U,W> newUpdater(Class<U> tclass,
+                                                                    Class<@NonNull W> vclass,
                                                                     String fieldName) {
         return new AtomicReferenceFieldUpdaterImpl<U,W>
             (tclass, vclass, fieldName, Reflection.getCallerClass());


### PR DESCRIPTION
My initial reaction was that this was similar to `ThreadLocal` and to
`AtomicReference`+`AtomicReferenceArray`
(https://github.com/jspecify/jdk/commit/a398fe4009ddf77578af49697c3f3a4211fc8adb
 -- which incidentally I can upstream if you're interested!): If you
choose a non-nullable type argument, then it's on you to make sure that
the thing you're updating isn't set to `null` at construction time by
the default constructor (or at least that you'll be careful because
you're _aware_ that it's set to `null` at construction time).

(Under a Checker Framework approach, then, we would likely write
`<@Nullable V>` instead of `<V extends @Nullable Object>`.)

However, `AtomicReferenceFieldUpdater` adds _another_ wrinkle: If you
pick a _nullable_ type argument, then you are able to write `null` to a
field that should be non-nullable.

Still, I feel good about this approach for JSpecify: It at least lets
you declare your `AtomicReferenceFieldUpdater` in a way that expresses
_consistent_ nullness between reads and writes.

(A Checker Framework approach might be to follow its existing precedent
for reflection APIs: All reads might return null; no writes allow null.
However, that might not be expressible through APIs that use functional
types like `UnaryOperator`....)
