### PR TITLE
Make `enumerate` accept `@Nullable Thread[]` (ditto `ThreadGroup`).

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -387,7 +387,7 @@ public
      *
      * @since   1.0
      */
-    public  int enumerate(Thread list[]) {
+    public  int enumerate(@Nullable Thread[] list) {
         checkAccess();
         return enumerate(list, 0, true);
     }
@@ -425,7 +425,7 @@ public
      *
      * @since   1.0
      */
-    public  int enumerate(Thread list[], boolean recurse) {
+    public  int enumerate(@Nullable Thread[] list, boolean recurse) {
         checkAccess();
         return enumerate(list, 0, recurse);
     }
@@ -525,7 +525,7 @@ public
      *
      * @since   1.0
      */
-    public  int enumerate(ThreadGroup list[]) {
+    public  int enumerate(@Nullable ThreadGroup[] list) {
         checkAccess();
         return enumerate(list, 0, true);
     }
@@ -563,7 +563,7 @@ public
      *
      * @since   1.0
      */
-    public  int enumerate(ThreadGroup list[], boolean recurse) {
+    public  int enumerate(@Nullable ThreadGroup[] list, boolean recurse) {
         checkAccess();
         return enumerate(list, 0, recurse);
     }


### PR DESCRIPTION
Since the method only writes to the array, it is fine with either a
nullable element type or a non-nullable element type. (I'm operating
under the usual assumption that tools treat arrays as covariant. For
purposes of Checker Framework users who set `-AinvariantArrays`, we
could consider using `@PolyNull` instead in eisop.)

This change is prompted by a Kotlin caller that passes an array of
`Thread?` because Kotlin won't allow an uninitialized array of `Thread`.
In Java, I would expect most users to allocate an uninitialized array of
`[@NonNull] Thread` and pass that.

(This is a pretty weird API, though, since it requires you to pass in an
array that you pre-size for the number of threads you expect and so you
might overshoot and end up (I assume; the docs are not clear) with nulls
in the result....)
