### PR TITLE
Permit a null `password` in `KeyStore.getKey`.

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1051,7 +1051,7 @@ public  class KeyStore {
      * @exception UnrecoverableKeyException if the key cannot be recovered
      * (e.g., the given password is wrong).
      */
-    public final @Nullable Key getKey(String alias, char[] password)
+    public final @Nullable Key getKey(String alias, char @Nullable [] password)
         throws KeyStoreException, NoSuchAlgorithmException,
             UnrecoverableKeyException
     {


### PR DESCRIPTION
The class's Javadoc is inconsistent about documenting parameter
nullness: Sometimes it documents that a method throws NPE (or IAE...) if
parameter `foo` is null; sometimes it documents that parameter `bar` may
be null. Other times, it's silent :(

My defense of `@Nullable` here is:

- I see code inside Google that passes a literal `null` as the password.
- I even see code that does so inside the JDK:
  https://github.com/openjdk/jdk/blob/4c2e54fb055bee0af5cd838fdd32a0f7902d51e3/src/java.base/share/classes/sun/security/tools/keytool/Main.java#L3812
- The code is implemented to [call
  `engineGetKey`](https://github.com/jspecify/jdk/blob/7edfe499a1389be6dc445d173963489c27c71181/src/java.base/share/classes/java/security/KeyStore.java#L1061),
  and at least [one implementation of that method _requires_ a null
  `password`](https://github.com/openjdk/jdk/blob/4c2e54fb055bee0af5cd838fdd32a0f7902d51e3/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java#L297-L299).
