### PR TITLE
Annotate the `arg` parameter of `Observer.update` as `@Nullable`.

### DIFF
--- a/src/java.base/share/classes/java/util/Observer.java
+++ b/src/java.base/share/classes/java/util/Observer.java
@@ -53,5 +53,5 @@ public interface Observer {
      * @param   arg   an argument passed to the {@code notifyObservers}
      *                 method.
      */
-    void update(Observable o, Object arg);
+    void update(Observable o, @Nullable Object arg);
 }


### PR DESCRIPTION
While there is no information about nullness in the docs for `Observer`
itself, we can find enough information in the docs for sibling class
`Observable`:

- [`notifyObservers()` is equivalent to
  `notifyObservers(null)`.](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Observable.html#notifyObservers())
- [`notifyObservers(@Nullable Object arg)` calls `update`, passing `arg`
  to
  `Observer.update`.](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Observable.html#notifyObservers())
