### PR TITLE
Annotate `computeIfPresent` and `compute` more like the Checker Framework and Kotlin do.

### DIFF
--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -1189,8 +1189,8 @@ public class HashMap<K extends @Nullable Object,V extends @Nullable Object> exte
      * remapping function modified this map
      */
     @Override
-    public V computeIfPresent(K key,
-                              BiFunction<? super K, ? super @NonNull V, ? extends V> remappingFunction) {
+    public @Nullable V computeIfPresent(K key,
+                              BiFunction<? super K, ? super @NonNull V, ? extends @Nullable V> remappingFunction) {
         if (remappingFunction == null)
             throw new NullPointerException();
         Node<K,V> e; V oldValue;
@@ -1222,8 +1222,8 @@ public class HashMap<K extends @Nullable Object,V extends @Nullable Object> exte
      * remapping function modified this map
      */
     @Override
-    public V compute(K key,
-                     BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+    public @Nullable V compute(K key,
+                     BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
         if (remappingFunction == null)
             throw new NullPointerException();
         int hash = hash(key);

--- a/src/java.base/share/classes/java/util/Hashtable.java
+++ b/src/java.base/share/classes/java/util/Hashtable.java
@@ -1088,7 +1088,7 @@ public class Hashtable<K,V>
      * remapping function modified this map
      */
     @Override
-    public synchronized V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    public synchronized @Nullable V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends @Nullable V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
 
         Entry<?,?> tab[] = table;
@@ -1130,7 +1130,7 @@ public class Hashtable<K,V>
      * remapping function modified this map
      */
     @Override
-    public synchronized V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+    public synchronized @Nullable V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
 
         Entry<?,?> tab[] = table;

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1094,8 +1094,8 @@ public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
      * @since 1.8
      */
-    default V computeIfPresent(K key,
-            BiFunction<? super K, ? super @NonNull V, ? extends V> remappingFunction) {
+    default @Nullable V computeIfPresent(K key,
+            BiFunction<? super K, ? super @NonNull V, ? extends @Nullable V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
         V oldValue;
         if ((oldValue = get(key)) != null) {
@@ -1186,8 +1186,8 @@ public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
      * @since 1.8
      */
-    default V compute(K key,
-            BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+    default @Nullable V compute(K key,
+            BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
         V oldValue = get(key);
 

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -1812,7 +1812,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @throws RuntimeException or Error if the remappingFunction does so,
      *         in which case the mapping is unchanged
      */
-    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    public @Nullable V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends @Nullable V> remappingFunction) {
         if (key == null || remappingFunction == null)
             throw new NullPointerException();
         int h = spread(key.hashCode());
@@ -1904,8 +1904,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @throws RuntimeException or Error if the remappingFunction does so,
      *         in which case the mapping is unchanged
      */
-    public V compute(K key,
-                     BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+    public @Nullable V compute(K key,
+                     BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
         if (key == null || remappingFunction == null)
             throw new NullPointerException();
         int h = spread(key.hashCode());

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentMap.java
@@ -370,8 +370,8 @@ public interface ConcurrentMap<K,V> extends Map<K,V> {
      * @since 1.8
      */
     @Override
-    default V computeIfPresent(K key,
-            BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    default @Nullable V computeIfPresent(K key,
+            BiFunction<? super K, ? super V, ? extends @Nullable V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
         for (V oldValue; (oldValue = get(key)) != null; ) {
             V newValue = remappingFunction.apply(key, oldValue);
@@ -418,8 +418,8 @@ public interface ConcurrentMap<K,V> extends Map<K,V> {
      * @since 1.8
      */
     @Override
-    default V compute(K key,
-                      BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+    default @Nullable V compute(K key,
+                      BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
         retry: for (;;) {
             V oldValue = get(key);
             // if putIfAbsent fails, opportunistically use its return value

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -1483,8 +1483,8 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
      *         or the remappingFunction is null
      * @since 1.8
      */
-    public V computeIfPresent(K key,
-                              BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    public @Nullable V computeIfPresent(K key,
+                              BiFunction<? super K, ? super V, ? extends @Nullable V> remappingFunction) {
         if (key == null || remappingFunction == null)
             throw new NullPointerException();
         Node<K,V> n; V v;
@@ -1515,8 +1515,8 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
      *         or the remappingFunction is null
      * @since 1.8
      */
-    public V compute(K key,
-                     BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+    public @Nullable V compute(K key,
+                     BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
         if (key == null || remappingFunction == null)
             throw new NullPointerException();
         for (;;) {


### PR DESCRIPTION
In contrast, for _`computeIfAbsent`_, I've kept the signature _without_
`@Nullable` on the function result type and method return type. This is
far more convenient for most callers, and it just might not cause
problems for anyone: Callers of `computeIfAbsent` might _always_ provide
a function that elects to insert a value (as expressed by returning a
non-null value).

I think this gives us the signatures that we'll want for the long term
for `Map`, though of course we'd revisit if we chose to include
`@PolyNull`.

Previously:

- https://github.com/jspecify/jdk/pull/14#issuecomment-1642254198
- https://github.com/jspecify/jdk/pull/19#issuecomment-1622173811

Note that this PR excludes `java.util.Properties` because there are a
number of other changes that I'm going to make to it (and then
upstream).
