### PR TITLE
Finish annotating the concurrent queues.

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
@@ -403,7 +403,7 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
-    public E poll() {
+    public @Nullable E poll() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {
@@ -425,7 +425,7 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public @Nullable E poll(long timeout, TimeUnit unit) throws InterruptedException {
         long nanos = unit.toNanos(timeout);
         final ReentrantLock lock = this.lock;
         lock.lockInterruptibly();
@@ -441,7 +441,7 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
         }
     }
 
-    public E peek() {
+    public @Nullable E peek() {
         final ReentrantLock lock = this.lock;
         lock.lock();
         try {

--- a/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
@@ -35,6 +35,7 @@
 
 package java.util.concurrent;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.invoke.MethodHandles;
@@ -90,6 +91,7 @@ import java.util.function.Predicate;
  * @author Doug Lea
  * @param <E> the type of elements held in this queue
  */
+@NullMarked
 public class LinkedTransferQueue<E> extends AbstractQueue<E>
     implements TransferQueue<E>, java.io.Serializable {
     private static final long serialVersionUID = -3223113410248163686L;
@@ -1372,14 +1374,14 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
         throw new InterruptedException();
     }
 
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public @Nullable E poll(long timeout, TimeUnit unit) throws InterruptedException {
         E e = xfer(null, false, TIMED, unit.toNanos(timeout));
         if (e != null || !Thread.interrupted())
             return e;
         throw new InterruptedException();
     }
 
-    public E poll() {
+    public @Nullable E poll() {
         return xfer(null, false, NOW, 0);
     }
 
@@ -1424,7 +1426,7 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
         return new Itr();
     }
 
-    public E peek() {
+    public @Nullable E peek() {
         restartFromHead: for (;;) {
             for (Node p = head; p != null;) {
                 Object item = p.item;

--- a/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
@@ -937,7 +937,7 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
      *         specified waiting time elapses before an element is present
      * @throws InterruptedException {@inheritDoc}
      */
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public @Nullable E poll(long timeout, TimeUnit unit) throws InterruptedException {
         E e = transferer.transfer(null, true, unit.toNanos(timeout));
         if (e != null || !Thread.interrupted())
             return e;
@@ -951,7 +951,7 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
      * @return the head of this queue, or {@code null} if no
      *         element is available
      */
-    public E poll() {
+    public @Nullable E poll() {
         return transferer.transfer(null, true, 0);
     }
 
@@ -1058,7 +1058,7 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
      *
      * @return {@code null}
      */
-    public E peek() {
+    public @Nullable E peek() {
         return null;
     }
 

--- a/src/java.base/share/classes/java/util/concurrent/TransferQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/TransferQueue.java
@@ -35,6 +35,8 @@
 
 package java.util.concurrent;
 
+import org.jspecify.annotations.NullMarked;
+
 /**
  * A {@link BlockingQueue} in which producers may wait for consumers
  * to receive elements.  A {@code TransferQueue} may be useful for
@@ -65,6 +67,7 @@ package java.util.concurrent;
  * @author Doug Lea
  * @param <E> the type of elements held in this queue
  */
+@NullMarked
 public interface TransferQueue<E> extends BlockingQueue<E> {
     /**
      * Transfers the element to a waiting consumer immediately, if possible.


### PR DESCRIPTION
A couple classes were not yet `@NullMarked`.

A couple others _were_ `@NullMarked` but were missing necessary
`@Nullable` annotations.
