### PR TITLE
Make `KeyStore.setKeyEntry` allow a null `password` and `chain`.

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1162,8 +1162,8 @@ public  class KeyStore {
      * (loaded), the given key cannot be protected, or this operation fails
      * for some other reason
      */
-    public final void setKeyEntry(String alias, Key key, char[] password,
-                                  Certificate[] chain)
+    public final void setKeyEntry(String alias, Key key, char @Nullable [] password,
+                                  Certificate @Nullable [] chain)
         throws KeyStoreException
     {
         if (!initialized) {
@@ -1203,7 +1203,7 @@ public  class KeyStore {
      * (loaded), or if this operation fails for some other reason.
      */
     public final void setKeyEntry(String alias, byte[] key,
-                                  Certificate[] chain)
+                                  Certificate @Nullable [] chain)
         throws KeyStoreException
     {
         if (!initialized) {


### PR DESCRIPTION
- `chain` is "only required if the given key is of type `PrivateKey`."
  (OK, the 3-arg overload says "only _useful_ if the protected key is of
  type `PrivateKey`" instead, but _surely_ it's fine, and I see
  null-handling in some implementations of the
  `KeyStoreSpi.engineSetKeyEntry` overload that it calls.)

- `password` is annoyingly unclear. You may recall
  https://github.com/jspecify/jdk/pull/29... :) In this case, I can see
  [a JDK call that passes the result of
  `promptForKeyPass`](https://github.com/openjdk/jdk/blob/752121114f424d8e673ee8b7bb85f7705a82b9cc/src/java.base/share/classes/sun/security/tools/keytool/Main.java#L2041-L2056),
  and I can see that [`promptForKeyPass` can return
  `null`](https://github.com/openjdk/jdk/blob/752121114f424d8e673ee8b7bb85f7705a82b9cc/src/java.base/share/classes/sun/security/tools/keytool/Main.java#L1768).
  And here's [a JDK _test_ that has some logic for passing
  `null`](https://github.com/openjdk/jdk/blob/752121114f424d8e673ee8b7bb85f7705a82b9cc/test/lib/jdk/test/lib/security/KeyStoreUtils.java#L208-L217).
  And we again have code inside Google that passes `null`.
