### PR TITLE
Allow `Node.setTextContent` to be called with a null argument.

### DIFF
--- a/src/java.xml/share/classes/org/w3c/dom/Node.java
+++ b/src/java.xml/share/classes/org/w3c/dom/Node.java
@@ -806,7 +806,7 @@ public interface Node {
      *
      * @since 1.5, DOM Level 3
      */
-    public void setTextContent(String textContent)
+    public void setTextContent(@Nullable String textContent)
                                          throws DOMException;
 
     /**


### PR DESCRIPTION
Compare https://github.com/jspecify/jdk/pull/24. The motivation is the
same as it was there (namely, Kotlin getter-setter pairs).
