### PR TITLE
Annotate `Socket` and related classes.

### DIFF
--- a/src/java.base/share/classes/java/net/DatagramSocket.java
+++ b/src/java.base/share/classes/java/net/DatagramSocket.java
@@ -27,6 +27,8 @@ package java.net;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.channels.DatagramChannel;
@@ -68,7 +70,7 @@ import java.util.Collections;
  * @see     java.nio.channels.DatagramChannel
  * @since 1.0
  */
-@AnnotatedFor({"interning"})
+@NullMarked
 public
 @UsesObjectEquals class DatagramSocket implements java.io.Closeable {
     /**
@@ -240,7 +242,7 @@ public
      * @see SecurityManager#checkListen
      * @since   1.4
      */
-    public DatagramSocket(SocketAddress bindaddr) throws SocketException {
+    public DatagramSocket(@Nullable SocketAddress bindaddr) throws SocketException {
         // create a datagram socket.
         createImpl();
         if (bindaddr != null) {
@@ -301,7 +303,7 @@ public
      * @see SecurityManager#checkListen
      * @since   1.1
      */
-    public DatagramSocket(int port, InetAddress laddr) throws SocketException {
+    public DatagramSocket(int port, @Nullable InetAddress laddr) throws SocketException {
         this(new InetSocketAddress(laddr, port));
     }
 
@@ -375,7 +377,7 @@ public
      *         not supported by this socket.
      * @since 1.4
      */
-    public synchronized void bind(SocketAddress addr) throws SocketException {
+    public synchronized void bind(@Nullable SocketAddress addr) throws SocketException {
         if (isClosed())
             throw new SocketException("Socket is closed");
         if (isBound())
@@ -558,7 +560,7 @@ public
      *
      * @return the address to which this socket is connected.
      */
-    public InetAddress getInetAddress() {
+    public @Nullable InetAddress getInetAddress() {
         return connectedAddress;
     }
 
@@ -592,7 +594,7 @@ public
      * @see #connect(SocketAddress)
      * @since 1.4
      */
-    public SocketAddress getRemoteSocketAddress() {
+    public @Nullable SocketAddress getRemoteSocketAddress() {
         if (!isConnected())
             return null;
         return new InetSocketAddress(getInetAddress(), getPort());
@@ -609,7 +611,7 @@ public
      * @since 1.4
      */
 
-    public SocketAddress getLocalSocketAddress() {
+    public @Nullable SocketAddress getLocalSocketAddress() {
         if (isClosed())
             return null;
         if (!isBound())
@@ -850,7 +852,7 @@ public
      *          method does not allow the operation
      * @since   1.1
      */
-    public InetAddress getLocalAddress() {
+    public @Nullable InetAddress getLocalAddress() {
         if (isClosed())
             return null;
         InetAddress in = null;
@@ -1267,7 +1269,7 @@ public
      * @since 1.4
      * @spec JSR-51
      */
-    public DatagramChannel getChannel() {
+    public @Nullable DatagramChannel getChannel() {
         return null;
     }
 
@@ -1344,7 +1346,7 @@ public
      *
      * @since 9
      */
-    public <T> DatagramSocket setOption(SocketOption<T> name, T value)
+    public <T extends @Nullable Object> DatagramSocket setOption(SocketOption<T> name, T value)
         throws IOException
     {
         getImpl().setOption(name, value);
@@ -1374,7 +1376,7 @@ public
      *
      * @since 9
      */
-    public <T> T getOption(SocketOption<T> name) throws IOException {
+    public <T extends @Nullable Object> T getOption(SocketOption<T> name) throws IOException {
         return getImpl().getOption(name);
     }
 

--- a/src/java.base/share/classes/java/net/DatagramSocket.java
+++ b/src/java.base/share/classes/java/net/DatagramSocket.java
@@ -26,7 +26,6 @@
 package java.net;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
-import org.checkerframework.framework.qual.AnnotatedFor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/src/java.base/share/classes/java/net/MulticastSocket.java
+++ b/src/java.base/share/classes/java/net/MulticastSocket.java
@@ -85,6 +85,7 @@ import java.util.Set;
  * @author Pavani Diwanji
  * @since  1.1
  */
+@NullMarked
 public
 class MulticastSocket extends DatagramSocket {
 

--- a/src/java.base/share/classes/java/net/MulticastSocket.java
+++ b/src/java.base/share/classes/java/net/MulticastSocket.java
@@ -25,6 +25,10 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullUnmarked;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -164,7 +168,7 @@ class MulticastSocket extends DatagramSocket {
      *
      * @since 1.4
      */
-    public MulticastSocket(SocketAddress bindaddr) throws IOException {
+    public MulticastSocket(@Nullable SocketAddress bindaddr) throws IOException {
         super((SocketAddress) null);
 
         // Enable SO_REUSEADDR before binding
@@ -388,7 +392,7 @@ class MulticastSocket extends DatagramSocket {
      * @see SecurityManager#checkMulticast(InetAddress)
      * @since 1.4
      */
-    public void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf)
+    public void joinGroup(SocketAddress mcastaddr, @Nullable NetworkInterface netIf)
         throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
@@ -435,7 +439,7 @@ class MulticastSocket extends DatagramSocket {
      * @see SecurityManager#checkMulticast(InetAddress)
      * @since 1.4
      */
-    public void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf)
+    public void leaveGroup(SocketAddress mcastaddr, @Nullable NetworkInterface netIf)
         throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
@@ -468,6 +472,7 @@ class MulticastSocket extends DatagramSocket {
      * the underlying protocol, such as a TCP error.
      * @see #getInterface()
      */
+    @NullUnmarked // TODO(cpovirk): @Nullable parameter or not?
     public void setInterface(InetAddress inf) throws SocketException {
         if (isClosed()) {
             throw new SocketException("Socket is closed");
@@ -553,6 +558,7 @@ class MulticastSocket extends DatagramSocket {
      * @see #getNetworkInterface()
      * @since 1.4
      */
+    @NullUnmarked // TODO(cpovirk): @Nullable parameter or not?
     public void setNetworkInterface(NetworkInterface netIf)
         throws SocketException {
 

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -26,7 +26,6 @@
 package java.net;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
-import org.checkerframework.framework.qual.AnnotatedFor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -27,6 +27,8 @@ package java.net;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import jdk.internal.misc.JavaNetSocketAccess;
 import jdk.internal.misc.SharedSecrets;
@@ -58,7 +60,7 @@ import java.util.Collections;
  * @see     java.nio.channels.ServerSocketChannel
  * @since   1.0
  */
-@AnnotatedFor({"interning"})
+@NullMarked
 public
 @UsesObjectEquals class ServerSocket implements java.io.Closeable {
     /**
@@ -236,7 +238,7 @@ public
      * @see SecurityManager#checkListen
      * @since   1.1
      */
-    public ServerSocket(int port, int backlog, InetAddress bindAddr) throws IOException {
+    public ServerSocket(int port, int backlog, @Nullable InetAddress bindAddr) throws IOException {
         setImpl();
         if (port < 0 || port > 0xFFFF)
             throw new IllegalArgumentException(
@@ -335,7 +337,7 @@ public
      *          SocketAddress subclass not supported by this socket
      * @since 1.4
      */
-    public void bind(SocketAddress endpoint) throws IOException {
+    public void bind(@Nullable SocketAddress endpoint) throws IOException {
         bind(endpoint, 50);
     }
 
@@ -364,7 +366,7 @@ public
      *          SocketAddress subclass not supported by this socket
      * @since 1.4
      */
-    public void bind(SocketAddress endpoint, int backlog) throws IOException {
+    public void bind(@Nullable SocketAddress endpoint, int backlog) throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
         if (!oldImpl && isBound())
@@ -412,7 +414,7 @@ public
      *
      * @see SecurityManager#checkConnect
      */
-    public InetAddress getInetAddress() {
+    public @Nullable InetAddress getInetAddress() {
         if (!isBound())
             return null;
         try {
@@ -480,7 +482,7 @@ public
      * @since 1.4
      */
 
-    public SocketAddress getLocalSocketAddress() {
+    public @Nullable SocketAddress getLocalSocketAddress() {
         if (!isBound())
             return null;
         return new InetSocketAddress(getInetAddress(), getLocalPort());
@@ -614,7 +616,7 @@ public
      * @since 1.4
      * @spec JSR-51
      */
-    public ServerSocketChannel getChannel() {
+    public @Nullable ServerSocketChannel getChannel() {
         return null;
     }
 
@@ -958,7 +960,7 @@ public
      *
      * @since 9
      */
-    public <T> ServerSocket setOption(SocketOption<T> name, T value)
+    public <T extends @Nullable Object> ServerSocket setOption(SocketOption<T> name, T value)
         throws IOException
     {
         getImpl().setOption(name, value);
@@ -988,7 +990,7 @@ public
      *
      * @since 9
      */
-    public <T> T getOption(SocketOption<T> name) throws IOException {
+    public <T extends @Nullable Object> T getOption(SocketOption<T> name) throws IOException {
         return getImpl().getOption(name);
     }
 

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -167,7 +167,7 @@ public
      * such as a TCP error.
      * @since   1.1
      */
-    protected Socket(SocketImpl impl) throws SocketException {
+    protected Socket(@Nullable SocketImpl impl) throws SocketException {
         this.impl = impl;
         if (impl != null) {
             checkOldImpl();

--- a/src/java.base/share/classes/java/net/SocketOption.java
+++ b/src/java.base/share/classes/java/net/SocketOption.java
@@ -25,6 +25,10 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
 /**
  * A socket option associated with a socket.
  *
@@ -40,8 +44,8 @@ package java.net;
  *
  * @see StandardSocketOptions
  */
-
-public interface SocketOption<T> {
+@NullMarked
+public interface SocketOption<T extends @Nullable Object> {
 
     /**
      * Returns the name of the socket option.
@@ -55,5 +59,5 @@ public interface SocketOption<T> {
      *
      * @return the type of the socket option value
      */
-    Class<T> type();
+    Class<@NonNull T> type();
 }


### PR DESCRIPTION
Notes:

- `ServerSocket.setSocketFactory` "permits" `null` in the sense that
  passing `null` is a no-op if no factory has been set yet. If a factory
  has already been set, then passing `null` throws an exception. I
  figure that that means it's best annotated as non-nullable, since it's
  hard for me to imagine that anyone actually wants to pass `null`.
  (Possibly there was another method similar to this one, either in this
  PR or in another one? I forget.)
- The 2-arg `DatagramSocket` constructor says nothing about `null`. I
  did find [a test that checks that users can pass `null` successfully](https://github.com/openjdk/jdk/blob/9559e035d2692d9d61bec2a13b5239a98db077ac/test/jdk/java/net/DatagramSocket/Constructor.java#L75),
  though, and the handling of `null` seems in line with what we see in
  other `net` classes.
