### PR TITLE
Annotate `orElseGet` as able to produce null values.

### DIFF
--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -373,7 +373,7 @@ public final  class Optional<T> {
      * @throws NullPointerException if no value is present and the supplying
      *         function is {@code null}
      */
-    public T orElseGet(Supplier<? extends T> supplier) {
+    public @Nullable T orElseGet(Supplier<? extends @Nullable T> supplier) {
         return value != null ? value : supplier.get();
     }
 

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -359,6 +359,7 @@ public final  class Optional<T> {
      *        May be {@code null}.
      * @return the value, if present, otherwise {@code other}
      */
+    // We would use an annotation like @PolyNull here if JSpecify offered one.
     public @Nullable T orElse(@Nullable T other) {
         return value != null ? value : other;
     }
@@ -373,6 +374,7 @@ public final  class Optional<T> {
      * @throws NullPointerException if no value is present and the supplying
      *         function is {@code null}
      */
+    // We would use an annotation like @PolyNull here if JSpecify offered one.
     public @Nullable T orElseGet(Supplier<? extends @Nullable T> supplier) {
         return value != null ? value : supplier.get();
     }


### PR DESCRIPTION
Fixes https://github.com/jspecify/jspecify/issues/425

This takes us back to what we originally inherited from
[upstream](https://github.com/typetools/jdk/blob/7b360535a1f8ad40cb43326f63d9c0ecf2b630ab/src/java.base/share/classes/java/util/Optional.java#L415)
before I changed it in
https://github.com/jspecify/jdk/commit/d2ec17b2d678b968f710f94ac0477794948e004b.
