### PR TITLE
`Constructor.newInstance`: Permit a null array of args.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -481,7 +481,7 @@ public final class Constructor<T> extends Executable {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public  T newInstance(@Nullable Object ... initargs)
+    public  T newInstance(@Nullable Object @Nullable ... initargs)
         throws InstantiationException, IllegalAccessException,
                IllegalArgumentException, InvocationTargetException
     {


### PR DESCRIPTION
Compare
https://github.com/jspecify/jdk/commit/39c518822a63aa8655c55bb0b87695b92c70e8bd
for `Method.invoke`.

I'd stubbornly held on out `Constructor` because there's "no reason" to
ever pass a null array. That was purportedly in contrast to
`Method.invoke`, where you might naturally pass the same null array that
was provided to your implementation of `InvocationHandler`.

But then it occurred to me that, well, an `InvocationHandler` might
_also_ be written to call `Constructor.newInstance`, too. And sure
enough, I was able to find an example of that in Google's code.

It doesn't appear _common_. But I don't think my stubbornness here is
going to do anyone any good.
