### PR TITLE
Annotate trivial `java.net` exceptions for nullness.

### DIFF
--- a/src/java.base/share/classes/java/net/BindException.java
+++ b/src/java.base/share/classes/java/net/BindException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Signals that an error occurred while attempting to bind a
  * socket to a local address and port.  Typically, the port is
@@ -32,7 +35,7 @@ package java.net;
  *
  * @since   1.1
  */
-
+@NullMarked
 public class BindException extends SocketException {
     private static final long serialVersionUID = -5945005768251722951L;
 
@@ -43,7 +46,7 @@ public class BindException extends SocketException {
      * description of this error.
      * @param msg the detail message
      */
-    public BindException(String msg) {
+    public BindException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/ConnectException.java
+++ b/src/java.base/share/classes/java/net/ConnectException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Signals that an error occurred while attempting to connect a
  * socket to a remote address and port.  Typically, the connection
@@ -33,6 +36,7 @@ package java.net;
  *
  * @since   1.1
  */
+@NullMarked
 public class ConnectException extends SocketException {
     private static final long serialVersionUID = 3831404271622369215L;
 
@@ -43,7 +47,7 @@ public class ConnectException extends SocketException {
      * description of this error.
      * @param msg the detail message
      */
-    public ConnectException(String msg) {
+    public ConnectException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/MalformedURLException.java
+++ b/src/java.base/share/classes/java/net/MalformedURLException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -35,6 +38,7 @@ import java.io.IOException;
  * @author  Arthur van Hoff
  * @since   1.0
  */
+@NullMarked
 public class MalformedURLException extends IOException {
     private static final long serialVersionUID = -182787522200415866L;
 
@@ -50,7 +54,7 @@ public class MalformedURLException extends IOException {
      *
      * @param   msg   the detail message.
      */
-    public MalformedURLException(String msg) {
+    public MalformedURLException(@Nullable String msg) {
         super(msg);
     }
 }

--- a/src/java.base/share/classes/java/net/PortUnreachableException.java
+++ b/src/java.base/share/classes/java/net/PortUnreachableException.java
@@ -25,13 +25,16 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Signals that an ICMP Port Unreachable message has been
  * received on a connected datagram.
  *
  * @since   1.4
  */
-
+@NullMarked
 public class PortUnreachableException extends SocketException {
     private static final long serialVersionUID = 8462541992376507323L;
 
@@ -40,7 +43,7 @@ public class PortUnreachableException extends SocketException {
      * detail message.
      * @param msg the detail message
      */
-    public PortUnreachableException(String msg) {
+    public PortUnreachableException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/ProtocolException.java
+++ b/src/java.base/share/classes/java/net/ProtocolException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -34,6 +37,7 @@ import java.io.IOException;
  * @author  Chris Warth
  * @since   1.0
  */
+@NullMarked
 public
 class ProtocolException extends IOException {
     private static final long serialVersionUID = -6098449442062388080L;
@@ -44,7 +48,7 @@ class ProtocolException extends IOException {
      *
      * @param   message   the detail message.
      */
-    public ProtocolException(String message) {
+    public ProtocolException(@Nullable String message) {
         super(message);
     }
 

--- a/src/java.base/share/classes/java/net/SocketException.java
+++ b/src/java.base/share/classes/java/net/SocketException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -33,6 +36,7 @@ import java.io.IOException;
  * @author  Jonathan Payne
  * @since   1.0
  */
+@NullMarked
 public
 class SocketException extends IOException {
     private static final long serialVersionUID = -5935874303556886934L;
@@ -43,7 +47,7 @@ class SocketException extends IOException {
      *
      * @param msg the detail message.
      */
-    public SocketException(String msg) {
+    public SocketException(@Nullable String msg) {
         super(msg);
     }
 

--- a/src/java.base/share/classes/java/net/UnknownServiceException.java
+++ b/src/java.base/share/classes/java/net/UnknownServiceException.java
@@ -25,6 +25,9 @@
 
 package java.net;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -36,6 +39,7 @@ import java.io.IOException;
  * @author  unascribed
  * @since   1.0
  */
+@NullMarked
 public class UnknownServiceException extends IOException {
     private static final long serialVersionUID = -4169033248853639508L;
 
@@ -52,7 +56,7 @@ public class UnknownServiceException extends IOException {
      *
      * @param   msg   the detail message.
      */
-    public UnknownServiceException(String msg) {
+    public UnknownServiceException(@Nullable String msg) {
         super(msg);
     }
 }


### PR DESCRIPTION
All of these have a no-arg constructor, so there is already a way to
create an instance with no message. Thus, letting users pass a null
message to the `(String)` constructor doesn't introduce any problems.

Compare https://github.com/eisop/jdk/pull/81.
