### PR TITLE
Annotate the parameter of `canAccess` as `@Nullable`.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -449,7 +449,7 @@ public class AccessibleObject implements AnnotatedElement {
      */
     @CallerSensitive
     
-    public final boolean canAccess(Object obj) {
+    public final boolean canAccess(@Nullable Object obj) {
         if (!Member.class.isInstance(this)) {
             return override;
         }


### PR DESCRIPTION
https://github.com/typetools/jdk/pull/76 had added a `@CFComment` about
how it needs to be null in some cases, but naturally our autoconversion
script didn't know to change the annotations.

I should probably review the results of `git grep
'@CFComment.*nullness'` at the commit `autorewritten^` for any similar
required changes. (I did at least review the result of `git grep
'@CFComment[^:]*$'`, which didn't turn up anything new to do.)
