### PR TITLE
Improve annotations in `Arrays`:

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -1171,7 +1171,7 @@ public class Arrays {
      */
     @SuppressWarnings("unchecked")
     public static <T extends @Nullable Object> void parallelSort(T[] a, int fromIndex, int toIndex,
-                                        Comparator<? super T> cmp) {
+                                        @Nullable Comparator<? super T> cmp) {
         rangeCheck(a.length, fromIndex, toIndex);
         if (cmp == null)
             cmp = NaturalOrder.INSTANCE;
@@ -1508,7 +1508,7 @@ public class Arrays {
      *         {@code toIndex > a.length}
      */
     public static <T extends @Nullable Object> void sort(T[] a,  int fromIndex,  int toIndex,
-                                Comparator<? super T> c) {
+                                @Nullable Comparator<? super T> c) {
         if (c == null) {
             sort(a, fromIndex, toIndex);
         } else {
@@ -2382,7 +2382,7 @@ public class Arrays {
      * @throws ClassCastException if the search key is not comparable to the
      *         elements of the array.
      */
-    public static  int binarySearch(@Nullable  Object[] a, @Nullable  Object key) {
+    public static  int binarySearch(Object[] a, Object key) {
         return binarySearch0(a, 0, a.length, key);
     }
 
@@ -2426,8 +2426,8 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static  int binarySearch(@Nullable  Object[] a,  int fromIndex,  int toIndex,
-                                   @Nullable  Object key) {
+    public static  int binarySearch(Object[] a,  int fromIndex,  int toIndex,
+                                   Object key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
@@ -3239,8 +3239,8 @@ public class Arrays {
      *         if either array is {@code null}
      * @since 9
      */
-    public static boolean equals(Object[] a, int aFromIndex, int aToIndex,
-                                 Object[] b, int bFromIndex, int bToIndex) {
+    public static boolean equals(@Nullable Object[] a, int aFromIndex, int aToIndex,
+                                 @Nullable Object[] b, int bFromIndex, int bToIndex) {
         rangeCheck(a.length, aFromIndex, aToIndex);
         rangeCheck(b.length, bFromIndex, bToIndex);
 
@@ -3278,7 +3278,7 @@ public class Arrays {
      * @throws NullPointerException if the comparator is {@code null}
      * @since 9
      */
-    public static <T extends @Nullable Object> boolean equals(T[] a, T[] a2, Comparator<? super T> cmp) {
+    public static <T extends @Nullable Object> boolean equals(T @Nullable [] a, T @Nullable [] a2, Comparator<? super T> cmp) {
         Objects.requireNonNull(cmp);
         if (a==a2)
             return true;
@@ -5815,7 +5815,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(boolean[] a, boolean[] b) {
+    public static int compare(boolean @Nullable [] a, boolean @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -5951,7 +5951,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(byte[] a, byte[] b) {
+    public static int compare(byte @Nullable [] a, byte @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6079,7 +6079,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compareUnsigned(byte[] a, byte[] b) {
+    public static int compareUnsigned(byte @Nullable [] a, byte @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6206,7 +6206,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(short[] a, short[] b) {
+    public static int compare(short @Nullable [] a, short @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6334,7 +6334,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compareUnsigned(short[] a, short[] b) {
+    public static int compareUnsigned(short @Nullable [] a, short @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6460,7 +6460,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(char[] a, char[] b) {
+    public static int compare(char @Nullable [] a, char @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6595,7 +6595,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(int[] a, int[] b) {
+    public static int compare(int @Nullable [] a, int @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6723,7 +6723,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compareUnsigned(int[] a, int[] b) {
+    public static int compareUnsigned(int @Nullable [] a, int @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6849,7 +6849,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(long[] a, long[] b) {
+    public static int compare(long @Nullable [] a, long @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -6977,7 +6977,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compareUnsigned(long[] a, long[] b) {
+    public static int compareUnsigned(long @Nullable [] a, long @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -7103,7 +7103,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(float[] a, float[] b) {
+    public static int compare(float @Nullable [] a, float @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -7238,7 +7238,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static int compare(double[] a, double[] b) {
+    public static int compare(double @Nullable [] a, double @Nullable [] b) {
         if (a == b)
             return 0;
         if (a == null || b == null)
@@ -7383,7 +7383,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static <T extends Comparable<? super T>> int compare(T[] a, T[] b) {
+    public static <T extends Comparable<? super T>> int compare(T @Nullable [] a, T @Nullable [] b) {
         if (a == b)
             return 0;
         // A null array is less than a non-null array
@@ -7537,7 +7537,7 @@ public class Arrays {
      * @throws NullPointerException if the comparator is {@code null}
      * @since 9
      */
-    public static <T extends @Nullable Object> int compare(T[] a, T[] b,
+    public static <T extends @Nullable Object> int compare(T @Nullable [] a, T @Nullable [] b,
                                   Comparator<? super T> cmp) {
         Objects.requireNonNull(cmp);
         if (a == b)
@@ -8701,7 +8701,7 @@ public class Arrays {
      *         if either array is {@code null}
      * @since 9
      */
-    public static int mismatch(Object[] a, Object[] b) {
+    public static int mismatch(@Nullable Object[] a, @Nullable Object[] b) {
         int length = Math.min(a.length, b.length); // Check null array refs
         if (a == b)
             return -1;
@@ -8776,8 +8776,8 @@ public class Arrays {
      * @since 9
      */
     public static int mismatch(
-            Object[] a, int aFromIndex, int aToIndex,
-            Object[] b, int bFromIndex, int bToIndex) {
+            @Nullable Object[] a, int aFromIndex, int aToIndex,
+            @Nullable Object[] b, int bFromIndex, int bToIndex) {
         rangeCheck(a.length, aFromIndex, aToIndex);
         rangeCheck(b.length, bFromIndex, bToIndex);
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -7383,7 +7383,7 @@ public class Arrays {
      *         lexicographically greater than the second array
      * @since 9
      */
-    public static <T extends Comparable<? super T>> int compare(T @Nullable [] a, T @Nullable [] b) {
+    public static <T extends Comparable<? super T>> int compare(@Nullable T @Nullable [] a, @Nullable T @Nullable [] b) {
         if (a == b)
             return 0;
         // A null array is less than a non-null array


### PR DESCRIPTION
- Add some `@Nullable` annotations for APIs added in Java 9.
- Add some `@Nullable` annotations for optional `Comparator` parameters.
- Remove some `@Nullable` annotations that I don't think are justified.
   - [some on `sort` that were `@PolyNull`
     upstream](https://github.com/typetools/jdk/commit/6630ac170c7c03f2b30414f1b329303df80bb22e#diff-51d93b3a0e9bcd89a7c9360d591f0bf77e9d72c93e00e9d071ce184bf1c0af4eL1057)
   - some on `binarySearch` from way back in
     https://github.com/typetools/jdk/commit/4d2993d87861d3b426bd6da87ffcc1c89c3cf337
