### PR TITLE
Remove method-level `Atomic` annotations.

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2944,19 +2944,19 @@ public final  class Class< T> implements java.io.Serializable,
         private static final long annotationDataOffset
                 = unsafe.objectFieldOffset(Class.class, "annotationData");
 
-        static <T extends @Nullable Object> boolean casReflectionData(Class<?> clazz,
+        static <T> boolean casReflectionData(Class<?> clazz,
                                              SoftReference<ReflectionData<T>> oldData,
                                              SoftReference<ReflectionData<T>> newData) {
             return unsafe.compareAndSetObject(clazz, reflectionDataOffset, oldData, newData);
         }
 
-        static <T extends @Nullable Object> boolean casAnnotationType(Class<?> clazz,
+        static <T> boolean casAnnotationType(Class<?> clazz,
                                              AnnotationType oldType,
                                              AnnotationType newType) {
             return unsafe.compareAndSetObject(clazz, annotationTypeOffset, oldType, newType);
         }
 
-        static <T extends @Nullable Object> boolean casAnnotationData(Class<?> clazz,
+        static <T> boolean casAnnotationData(Class<?> clazz,
                                              AnnotationData oldData,
                                              AnnotationData newData) {
             return unsafe.compareAndSetObject(clazz, annotationDataOffset, oldData, newData);


### PR DESCRIPTION
They are unnecessary, troublesome, and probably wrong.

Unnecessary: We don't care about annotations on private and
package-private APIs because users don't interact with them. The only
reason that we have annotations here in the first place is that we we
automatically translated every occurrence of plain `<T>` to `<T extends
@Nullable Object>` in classes that were already annotated for nullness
in the upstream Checker Framework JDK. But that wasn't necessarily the
right thing to do for private and package-private members, since the
upstream Checker Framework JDK doesn't necessarily annotate those
properly (nor do we). So it's likely that the upstream code "should"
have used `<T extends [@NonNull] Object>`, which we would then have
automatically translated to `<T>`, thus avoiding this problem.

Troublesome: The JDK changed its definitions of these methods to no
longer contain a type parameter at all in later JDK versions. As a
result, we try to behave as if an annotation is present in a location
that does not exist. That leads to problems, as discussed in Google bug
323609832.

Probably wrong: I haven't looked much, but my guess is that a
`ReflectionData` instance is associated with a `Class<T>` object. So,
just as we declare `Class` with a non-nullable type parameter, we'd
likely want to do the same with `ReflectionData`. If we were to do that
(not that I bothered in this PR, though I could), then the `<T extends
@Nullable Object>` on the methods would create an out-of-bounds type
argument.
