### PR TITLE
Add missing `@Nullable` annotation to `IdentityHashMap.equals`.

### DIFF
--- a/src/java.base/share/classes/java/util/IdentityHashMap.java
+++ b/src/java.base/share/classes/java/util/IdentityHashMap.java
@@ -650,7 +650,7 @@ public class IdentityHashMap<K extends @Nullable Object,V extends @Nullable Obje
      * @see Object#equals(Object)
      */
     
-    public boolean equals( Object o) {
+    public boolean equals(@Nullable Object o) {
         if (o == this) {
             return true;
         } else if (o instanceof IdentityHashMap) {


### PR DESCRIPTION
See https://github.com/typetools/jdk/pull/137

Eventually, we'll rebase onto the upstream stubs, at which point we'd
get this for free. But let's pick it up now.