### PR TITLE
Annotate `Thread.enumerate` to accept arrays of nullable elements.

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1256,7 +1256,7 @@ public
      *          if {@link java.lang.ThreadGroup#checkAccess} determines that
      *          the current thread cannot access its thread group
      */
-    public static int enumerate(Thread tarray[]) {
+    public static int enumerate(@Nullable Thread[] tarray) {
         return currentThread().getThreadGroup().enumerate(tarray);
     }
 


### PR DESCRIPTION
This matches `ThreadGroup.enumerate`, which `Thread.enumerate` calls.

My reading of https://github.com/jspecify/jdk/pull/28 is that I'd meant
to cover both classes then, but apparently I didn't.

(For the Checker Framework, we'll use `@PolyNull` instead, as we do for
`ThreadGroup`.)

Fixes https://github.com/jspecify/jdk/issues/61
