### PR TITLE
Annotate `StackWalker`.

### DIFF
--- a/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/src/java.base/share/classes/java/lang/StackWalker.java
@@ -24,6 +24,9 @@
  */
 package java.lang;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import jdk.internal.reflect.CallerSensitive;
 
 import java.lang.invoke.MethodType;
@@ -86,6 +89,7 @@ import java.util.stream.Stream;
  *
  * @since 9
  */
+@NullMarked
 public final class StackWalker {
     /**
      * A {@code StackFrame} object represents a method invocation returned by
@@ -198,7 +202,7 @@ public final class StackWalker {
          *
          * @jvms 4.7.10 The {@code SourceFile} Attribute
          */
-        public String getFileName();
+        public @Nullable String getFileName();
 
         /**
          * Returns the line number of the source line containing the execution
@@ -483,7 +487,7 @@ public final class StackWalker {
      *         {@linkplain StackFrame stack frame}.
      */
     @CallerSensitive
-    public <T> T walk(Function<? super Stream<StackFrame>, ? extends T> function) {
+    public <T extends @Nullable Object> T walk(Function<? super Stream<StackFrame>, ? extends T> function) {
         // Returning a Stream<StackFrame> would be unsafe, as the stream could
         // be used to access the stack frames in an uncontrolled manner.  For
         // example, a caller might pass a Spliterator of stack frames after one


### PR DESCRIPTION
This builds on
https://github.com/typetools/jdk/commit/fd7576eb66877662b99e160e879ee3f27ca334cb.
I think that PR was actually unnecessary for Checker-Framework purposes
because type-parameter upper bounds default to `@Nullable` there, but we
do need such a change on the JSpecify side. This PR also adds a
`@Nullable` annotation to `StackFrame.getFileName()`.
