### PR TITLE
Add missing `@Nullable` annotation to `Locale.getExtension`.

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1465,7 +1465,7 @@ public final class Locale implements Cloneable, Serializable {
      * @see #UNICODE_LOCALE_EXTENSION
      * @since 1.7
      */
-    public String getExtension(char key) {
+    public @Nullable String getExtension(char key) {
         if (!LocaleExtensions.isValidKey(key)) {
             throw new IllegalArgumentException("Ill-formed extension key: " + key);
         }


### PR DESCRIPTION
This isn't a new API; we just missed this one.
