### PR TITLE
Add missing `@Nullable` annotation to `JarFile.getInputStream`.

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -849,7 +849,7 @@ public class JarFile extends ZipFile {
      * @throws IllegalStateException
      *         may be thrown if the jar file has been closed
      */
-    public synchronized InputStream getInputStream(ZipEntry ze)
+    public synchronized @Nullable InputStream getInputStream(ZipEntry ze)
         throws IOException
     {
         Objects.requireNonNull(ze, "ze");


### PR DESCRIPTION
This isn't a new API; we just missed this one.
