### PR TITLE
Annotate the new `repeat` API on `StringBuilder` and friends.

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1964,7 +1964,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      *
      * @since 21
      */
-    public AbstractStringBuilder repeat(CharSequence cs, int count) {
+    public AbstractStringBuilder repeat(@Nullable CharSequence cs, int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count is negative: " + count);
         } else if (count == 0) {

--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -735,7 +735,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
      * @since 21
      */
     @Override
-    public synchronized StringBuffer repeat(CharSequence cs, int count) {
+    public synchronized StringBuffer repeat(@Nullable CharSequence cs, int count) {
         toStringCache = null;
         super.repeat(cs, count);
         return this;

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -471,7 +471,7 @@ public final class StringBuilder
      * @since 21
      */
     @Override
-    public StringBuilder repeat(CharSequence cs, int count) {
+    public StringBuilder repeat(@Nullable CharSequence cs, int count) {
         super.repeat(cs, count);
         return this;
     }


### PR DESCRIPTION
I'm not sure that annotation in `AbstractStringBuilder` matter much, but
I'm not ruling it out that an expression could have that implicit type
if you wrote something like `b ? new StringBuilder() : new
StringBuffer()`. And anyway, it was nice to keep `AbstractStringBuilder`
up to date while having reference to its implementation so that I could
then easily cross-reference between it and the subclasses.
