### PR TITLE
Annotate `RecordComponent`.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
+++ b/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
@@ -25,6 +25,9 @@
 
 package java.lang.reflect;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import jdk.internal.access.SharedSecrets;
 import sun.reflect.annotation.AnnotationParser;
 import sun.reflect.annotation.TypeAnnotation;
@@ -46,6 +49,7 @@ import java.util.Objects;
  * @jls 8.10 Record Classes
  * @since 16
  */
+@NullMarked
 public final class RecordComponent implements AnnotatedElement {
     // declaring class
     private Class<?> clazz;
@@ -91,7 +95,7 @@ public final class RecordComponent implements AnnotatedElement {
      *
      * @jvms 4.7.9.1 Signatures
      */
-    public String getGenericSignature() {
+    public @Nullable String getGenericSignature() {
         return signature;
     }
 
@@ -178,7 +182,7 @@ public final class RecordComponent implements AnnotatedElement {
      * @throws NullPointerException {@inheritDoc}
      */
     @Override
-    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
         Objects.requireNonNull(annotationClass);
         return annotationClass.cast(declaredAnnotations().get(annotationClass));
     }


### PR DESCRIPTION
`getGenericSignature()` is not documented well, but I noticed that
`getGenericType()` compares the result of `getGenericSignature()`
against `null`, so that got me to verify that it can in fact return
`null`:

```
public class RecordComponentGenericSignature {
  record Rec(String s) {}

  public static void main(String[] args) {
    System.out.println(Rec.class.getRecordComponents()[0].getGenericSignature());
  }
}
```
