### PR TITLE
Annotate `ScopedValue.orElse`.

### DIFF
--- a/src/java.base/share/classes/java/lang/ScopedValue.java
+++ b/src/java.base/share/classes/java/lang/ScopedValue.java
@@ -26,6 +26,8 @@
 
 package java.lang;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.lang.ref.Reference;
@@ -684,7 +686,7 @@ public final class ScopedValue<T> {
      * @param other the value to return if not bound, can be {@code null}
      * @return the value of the scoped value if bound, otherwise {@code other}
      */
-    public T orElse(T other) {
+    public @Nullable T orElse(@Nullable T other) {
         Object obj = findBinding();
         if (obj != Snapshot.NIL) {
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
I'm doing this entirely in response to an observation that this is a new
API that would benefit from `@PolyNull`:

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2147#issuecomment-1997570950

I haven't tried to annotate the rest of the class.
