### PR TITLE
Accept a null array of parameter types for more methods.

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2518,7 +2518,7 @@ public final  class Class< T> implements java.io.Serializable,
      */
     
     @CallerSensitive
-    public Constructor<T> getConstructor(Class<?>... parameterTypes)
+    public Constructor<T> getConstructor(Class<?> @Nullable ... parameterTypes)
         throws NoSuchMethodException, SecurityException
     {
         @SuppressWarnings("removal")
@@ -2923,7 +2923,7 @@ public final  class Class< T> implements java.io.Serializable,
      * @since 1.1
      */
     @CallerSensitive
-    public Method getDeclaredMethod(String name, Class<?>... parameterTypes)
+    public Method getDeclaredMethod(String name, Class<?> @Nullable ... parameterTypes)
         throws NoSuchMethodException, SecurityException {
         Objects.requireNonNull(name);
         @SuppressWarnings("removal")
@@ -3020,7 +3020,7 @@ public final  class Class< T> implements java.io.Serializable,
      * @since 1.1
      */
     @CallerSensitive
-    public Constructor<T> getDeclaredConstructor(Class<?>... parameterTypes)
+    public Constructor<T> getDeclaredConstructor(Class<?> @Nullable ... parameterTypes)
         throws NoSuchMethodException, SecurityException
     {
         @SuppressWarnings("removal")


### PR DESCRIPTION
We already do this for `getMethod`. In fairness, `getMethod` has clear
docs about it. These other methods do not. Still, I think that
`@Nullable` is justified, as I discussed in
https://github.com/jspecify/jdk/issues/96

Fixes https://github.com/jspecify/jdk/issues/96
