### PR TITLE
Allow the supplier to return null in `requireNonNullElseGet`.

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -327,7 +327,7 @@ public final  class Objects {
      *        the {@code supplier.get()} value is {@code null}
      * @since 9
      */
-    public static <T> T requireNonNullElseGet(@Nullable T obj, Supplier<? extends T> supplier) {
+    public static <T> T requireNonNullElseGet(@Nullable T obj, Supplier<? extends @Nullable T> supplier) {
         return (obj != null) ? obj
                 : requireNonNull(requireNonNull(supplier, "supplier").get(), "supplier.get()");
     }


### PR DESCRIPTION
The object returned by the supplier will be checked with `requireNonNull`.