### PR TITLE
Mark the "previous value or `null`" type of `Properties.compute` as nullable.

### DIFF
--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -1515,7 +1515,7 @@ public class Properties extends Hashtable<Object,Object> {
 
     @Override
     public synchronized @Nullable Object compute(Object key,
-            BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+            BiFunction<? super Object, ? super @Nullable Object, ?> remappingFunction) {
         return map.compute(key, remappingFunction);
     }
 


### PR DESCRIPTION
This matches [what we have for
`Map.compute`](https://github.com/jspecify/jdk/blob/7cc2fbd5f404bf5403bd1375b47024a855838fef/src/java.base/share/classes/java/util/Map.java#L1247),
noting that `Properties` is a `Hashtable<Object, Object>` and so a
`Map<Object, Object>`.

See previous discussion in
https://github.com/jspecify/jdk/pull/114#discussion_r1888697414
