### PR TITLE
Bump jtreg to 7.5.1.

### DIFF
--- a/.github/workflows/jspecify.yml
+++ b/.github/workflows/jspecify.yml
@@ -28,7 +28,7 @@ jobs:
             libx11-dev libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev
     - name: Install jtreg
       run: |
-        wget https://builds.shipilev.net/jtreg/jtreg-7.5%2B1.zip -O /tmp/jtreg.zip
+        wget https://builds.shipilev.net/jtreg/jtreg-7.5.1%2B1.zip -O /tmp/jtreg.zip
         unzip /tmp/jtreg.zip -d /tmp/
     - name: Configure the JDK
       run: bash ./configure --with-jtreg=/tmp/jtreg --disable-warnings-as-errors


### PR DESCRIPTION
I'm assuming that this will fix...

```
checking jtreg jar existence... checking jtreg version number... 7.5-dev
configure: error: jtreg version is too old, at least version 7.5.1 is required
```

https://github.com/jspecify/jdk/actions/runs/13930673343/job/38986758885

...from my merge of the upstream JDK branch. (Ideally we'd do that will
a pull request, which would then be properly tested, but GitHub doesn't
make that easy.)

Hopefully that's the only problem. CI will let us know.

And I'll have to test locally next time....
