### PR TITLE
Allow calls to `Objects.hash` with a null varargs array.

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -139,7 +139,7 @@ public final class Objects {
     * @see Arrays#hashCode(Object[])
     * @see List#hashCode
     */
-    public static int hash(@Nullable Object... values) {
+    public static int hash(@Nullable Object @Nullable ... values) {
         return Arrays.hashCode(values);
     }
 


### PR DESCRIPTION
The documentation if anything implies that a null array is _not_
allowed. But it is, since the method delegates straight to
`Arrays.hashCode`, which accepts `null` (and even documents as much).
The JDK would be within its rights to change that in the future, but I
can't imagine they would risk the compatibility problems it would cause.

I do grant that it's somewhat unlikely that callers would pass a null
array. The reason that I care is that I'm [looking at](https://github.com/google/guava/pull/7859) making Guava's
ancient
[`Objects.hashCode`](https://github.com/google/guava/blob/990557ca1295e068e7a83a0ee4556ccbca2bc240/guava/src/com/google/common/base/Objects.java#L76)
call Java's `Objects.hash`—leading to a nullness error with the current
JDK stubs.
