### PR TITLE
Add some missing `@Nullable` annotations.

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -91,7 +91,7 @@ public class BufferedInputStream extends FilterInputStream {
      * indicator that this stream is closed. (The "in" field is also
      * nulled out on close.)
      */
-    protected volatile byte[] buf;
+    protected volatile byte @Nullable [] buf;
 
     /**
      * The index one greater than the index of the last valid byte in

--- a/src/java.base/share/classes/java/io/FilterInputStream.java
+++ b/src/java.base/share/classes/java/io/FilterInputStream.java
@@ -46,7 +46,7 @@ public class FilterInputStream extends InputStream {
     /**
      * The input stream to be filtered.
      */
-    protected volatile InputStream in;
+    protected volatile @Nullable InputStream in;
 
     /**
      * Creates a {@code FilterInputStream}

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2091,7 +2091,7 @@ public abstract  class ClassLoader {
      *
      * @since  9
      */
-    public final Package getDefinedPackage(String name) {
+    public final @Nullable Package getDefinedPackage(String name) {
         Objects.requireNonNull(name, "name cannot be null");
 
         NamedPackage p = packages.get(name);

--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -961,7 +961,7 @@ public final class URL implements java.io.Serializable {
      * or <CODE>null</CODE> if one does not exist
      * @since 1.3
      */
-    public String getQuery() {
+    public @Nullable String getQuery() {
         return query;
     }
 
@@ -983,7 +983,7 @@ public final class URL implements java.io.Serializable {
      * <CODE>null</CODE> if one does not exist
      * @since 1.3
      */
-    public String getUserInfo() {
+    public @Nullable String getUserInfo() {
         return userInfo;
     }
 
@@ -993,7 +993,7 @@ public final class URL implements java.io.Serializable {
      * @return  the authority part of this {@code URL}
      * @since 1.3
      */
-    public String getAuthority() {
+    public @Nullable String getAuthority() {
         return authority;
     }
 
@@ -1062,7 +1062,7 @@ public final class URL implements java.io.Serializable {
      * @return  the anchor (also known as the "reference") of this
      *          {@code URL}, or <CODE>null</CODE> if one does not exist
      */
-    public String getRef() {
+    public @Nullable String getRef() {
         return ref;
     }
 

--- a/src/java.base/share/classes/java/security/AlgorithmParameters.java
+++ b/src/java.base/share/classes/java/security/AlgorithmParameters.java
@@ -29,6 +29,7 @@ import java.io.*;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class is used as an opaque representation of cryptographic parameters.
@@ -420,7 +421,7 @@ public class AlgorithmParameters {
      * @return a formatted string describing the parameters, or {@code null}
      * if this parameter object has not been initialized.
      */
-    public final String toString() {
+    public final @Nullable String toString() {
         if (!this.initialized) {
             return null;
         }

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -644,7 +644,7 @@ public final  class Matcher implements MatchResult {
      *          or if the previous match operation failed
      */
     
-    public String group() {
+    public @Nullable String group() {
         return group(0);
     }
 

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -991,7 +991,7 @@ public abstract   class Component implements ImageObserver, MenuContainer,
      * Constructs a name for this component.  Called by {@code getName}
      * when the name is {@code null}.
      */
-    @Nullable String constructComponentName() {
+    String constructComponentName() {
         return null; // For strict compliance with prior platform versions, a Component
                      // that doesn't set its name should return null from
                      // getName()
@@ -1003,7 +1003,7 @@ public abstract   class Component implements ImageObserver, MenuContainer,
      * @see    #setName
      * @since 1.1
      */
-    public String getName() {
+    public @Nullable String getName() {
         if (name == null && !nameExplicitlySet) {
             synchronized(getObjectLock()) {
                 if (name == null && !nameExplicitlySet)

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -2668,7 +2668,7 @@ public  class Container extends Component {
      * @see #getComponentAt
      * @since 1.2
      */
-    public Component findComponentAt(int x, int y) {
+    public @Nullable Component findComponentAt(int x, int y) {
         return findComponentAt(x, y, true);
     }
 
@@ -2763,7 +2763,7 @@ public  class Container extends Component {
      * @see #getComponentAt
      * @since 1.2
      */
-    public Component findComponentAt(Point p) {
+    public @Nullable Component findComponentAt(Point p) {
         return findComponentAt(p.x, p.y);
     }
 

--- a/src/java.sql/share/classes/java/sql/ResultSet.java
+++ b/src/java.sql/share/classes/java/sql/ResultSet.java
@@ -652,7 +652,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      *             or {@code getBigDecimal(String columnLabel)}
      */
     @Deprecated(since="1.2")
-    BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException;
+    @Nullable BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -795,7 +795,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * if a database access error occurs or this method is
      *            called on a closed result set
      */
-    java.io.InputStream getBinaryStream(String columnLabel)
+    java.io.@Nullable InputStream getBinaryStream(String columnLabel)
         throws SQLException;
 
 
@@ -2493,7 +2493,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Blob getBlob(int columnIndex) throws SQLException;
+    @Nullable Blob getBlob(int columnIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -4115,7 +4115,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.7
      */
-     public <T extends @Nullable Object> @Nullable T getObject(int columnIndex, Class<T> type) throws SQLException;
+     public <T> @Nullable T getObject(int columnIndex, Class<T> type) throws SQLException;
 
 
     /**
@@ -4146,7 +4146,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.7
      */
-     public <T extends @Nullable Object> @Nullable T getObject(String columnLabel, Class<T> type) throws SQLException;
+     public <T> @Nullable T getObject(String columnLabel, Class<T> type) throws SQLException;
 
     //------------------------- JDBC 4.2 -----------------------------------
 


### PR DESCRIPTION
Most of these came to my attention during the testing of
[RedundantNullCheck](https://github.com/google/error-prone/pull/5121).

Notes:

- For `BufferedInputStream` and `FilterInputStream`, see
  https://github.com/jspecify/jdk/issues/128.
- For `URL`, the docs for `getAuthority()` don't mention `null`, but
  it's easy enough to demonstrate that `null` is a possible return
  value:
  ```java
  var u = new URL("mailto:foo@bar.com");
  System.out.println("authority " + u.getAuthority());
  ```
- `AlgorithmParameters.toString()` is gross but documented as such, as
  eamonnmcmanus points out.
- `Matcher.group()` is unfortunate: At one point, it could not return
  `null`, but that changed, as documented since
  [JDK-8274663](https://bugs.openjdk.org/browse/JDK-8274663). The change
  is a consequence of
  [`usePattern`](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/regex/Matcher.html#usePattern(java.util.regex.Pattern)),
  which was added all the way back in Java 5. I am a little tempted to
  lie here and leave the type as non-null.
- In `Component`, I also removed an annotation on the package-private
  helper method used by `getName()`.
- In `ResultSet`, `getBlob` and `getObject` have no documentatino about
  `null` returns. Gemini [wrote me some code that demonstrates the
  possible null returns](https://g.co/gemini/share/776a7669ae47).
- Also in `ResultSet`, I simplified some type-parameter declarations.
  This ensures that the `Class<T>` parameter has its type argument in
  bounds, and it makes no difference to the result type, which is always
  nullable, regardless of the type argument.

Fixes https://github.com/jspecify/jdk/issues/128
