### PR TITLE
Annotate `PushbackInputStream.buf` as `@Nullable`.

### DIFF
--- a/src/java.base/share/classes/java/io/PushbackInputStream.java
+++ b/src/java.base/share/classes/java/io/PushbackInputStream.java
@@ -60,7 +60,7 @@ public class PushbackInputStream extends FilterInputStream {
      * The pushback buffer.
      * @since   1.1
      */
-    protected byte[] buf;
+    protected byte @Nullable [] buf;
 
     /**
      * The position within the pushback buffer from which the next byte will


### PR DESCRIPTION
This follows https://github.com/google/xplat/commit/f7a56b3bffa48c2b7e1065b5eae5dd4046b59813

That commit does additionally add `@Nullable` to the `InputStream in`
constructor parameters. It looks like a null `in` leads to a stream that
doesn't work unless you later modify `FilterInputStream.in` directly, as
[the xplat copy
documents](https://github.com/google/xplat/commit/f7a56b3bffa48c2b7e1065b5eae5dd4046b59813#diff-f21cbb1ece57585a6b018af66249cc68cf16f32fbfc25fdecd2c47dc567abcc3R43-R44).
On the one hand, this is no different from its superclass
`FilterInputStream`, where we [included
`@Nullable`](https://github.com/jspecify/jdk/blob/cf198c06e3bd59572304f866b5cbf70781112f55/src/java.base/share/classes/java/io/FilterInputStream.java#L57-L60).
On the other hand, `FilterInputStream` specifically documents that
passing `null` is an intended use case, and we've seen people pass
`null` in practice with the intent of modifying the `in` field later. We
haven't seen that with `PushbackInputStream`, even in the rare instances
in which the class is subclassed.
