### PR TITLE
Disallow nullable type arguments to `toUnmodifiableList` and `toUnmodifiableSet`.

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -262,7 +262,7 @@ public final class Collectors {
      * <a href="../List.html#unmodifiable">unmodifiable List</a> in encounter order
      * @since 10
      */
-    public static <T extends @Nullable Object>
+    public static <T>
     Collector<T, ?, List<T>> toUnmodifiableList() {
         return new CollectorImpl<>(ArrayList::new, List::add,
                                    (left, right) -> { left.addAll(right); return left; },
@@ -320,7 +320,7 @@ public final class Collectors {
      * @since 10
      */
     @SuppressWarnings("unchecked")
-    public static <T extends @Nullable Object>
+    public static <T>
     Collector<T, ?, Set<T>> toUnmodifiableSet() {
         return new CollectorImpl<>(HashSet::new, Set::add,
                                    (left, right) -> {


### PR DESCRIPTION
(prompted by discussion on https://github.com/google/xplat/commit/f325f28921b74aebe5eef2a35172b286d9f7b94b)
