### PR TITLE
Update JSpecify annotations to version 1.0.1.

### DIFF
--- a/src/java.base/share/classes/org/jspecify/annotations/NonNull.java
+++ b/src/java.base/share/classes/org/jspecify/annotations/NonNull.java
@@ -25,18 +25,19 @@ import java.lang.annotation.Target;
 /**
  * Indicates that the annotated <a href="https://github.com/jspecify/jspecify/wiki/type-usages">type
  * usage</a> (commonly a parameter type or return type) is considered to <i>exclude</i> {@code null}
- * as a value; rarely needed within {@linkplain NullMarked null-marked} code.
+ * as a value; rarely needed within {@linkplain NullMarked null-marked} context.
  *
  * <p>This annotation serves two primary purposes:
  *
  * <ul>
  *   <li>To mark any sporadic non-null type usages inside a scope that is not ready to be fully
- *       {@link NullMarked} yet.
+ *       null-marked yet.
  *   <li>To perform a <i>non-null projection</i> of a type variable, explained below.
  * </ul>
  *
- * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * <p>For important information common to all four nullness annotations, see {@link
+ * org.jspecify.annotations}. To learn more about JSpecify, see <a
+ * href="https://jspecify.dev">jspecify.dev</a>.
  *
  * <h2 id="projection">Non-null projection</h2>
  *
@@ -45,17 +46,17 @@ import java.lang.annotation.Target;
  * nullable type argument.
  *
  * <pre>{@code
- * // All the below is null-marked code
+ * // Everything below is in null-marked context:
  *
- * class MyOptional<T> { ... }
+ * class MyOptional<T> { … }
  *
  * interface MyList<E extends @Nullable Object> {
  *   // Returns the first non-null element, if such element exists.
- *   MyOptional<E> firstNonNull() { ... } // problem here!
+ *   MyOptional<E> firstNonNull() { … } // problem here!
  * }
  *
- * MyList<@Nullable String> maybeNulls = ...
- * MyList<String> nonNulls = ...
+ * MyList<@Nullable String> maybeNulls = …
+ * MyList<String> nonNulls = …
  * }</pre>
  *
  * <p>Because {@code MyOptional} accepts only non-null type arguments, we need both {@code
@@ -70,7 +71,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * // Returns the first non-null element, if such element exists.
- * MyOptional<@NonNull E> firstNonNull() { ... } // problem fixed!
+ * MyOptional<@NonNull E> firstNonNull() { … } // problem fixed!
  * }</pre>
  *
  * <p>Here, {@code @NonNull E} selects the non-null form of the type argument, whether it was
@@ -79,16 +80,16 @@ import java.lang.annotation.Target;
  * <p>If {@code E} has a non-null upper bound, then the apparent projection {@code @NonNull E} is
  * redundant but harmless.
  *
- * <p><a href="Nullable.html#projection">Nullable projection</a> serves the equivalent purpose in
- * the opposite direction, and is far more commonly useful.
+ * <p>{@linkplain Nullable##projection Nullable projection} serves the equivalent purpose in the
+ * opposite direction, and is far more commonly useful.
  *
  * <p>If a type variable has <i>all</i> its usages being projected in one direction or the other, it
  * should be given a non-null upper bound, and any non-null projections can then be removed.
  *
  * <h2>Where it is applicable</h2>
  *
- * <p>{@code @NonNull} is applicable in all the <a href="Nullable.html#applicability">same
- * locations</a> as {@link Nullable}.
+ * <p>This annotation is applicable in all the {@linkplain Nullable##applicability same locations}
+ * as {@code Nullable}.
  */
 @Documented
 @Target(TYPE_USE)

--- a/src/java.base/share/classes/org/jspecify/annotations/NullMarked.java
+++ b/src/java.base/share/classes/org/jspecify/annotations/NullMarked.java
@@ -28,80 +28,71 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated element and the code transitively {@linkplain
- * javax.lang.model.element.Element#getEnclosedElements() enclosed} within it are <b>null-marked
- * code</b>: there, type usages are generally considered to exclude {@code null} as a value unless
- * specified otherwise. Using this annotation avoids the need to write {@link NonNull @NonNull} many
- * times throughout your code.
+ * javax.lang.model.element.Element#getEnclosedElements() enclosed} within it are in <b>null-marked
+ * context</b>: there, type usages are generally considered to exclude {@code null} as a value
+ * unless specified otherwise. Using this annotation avoids the need to write {@link
+ * NonNull @NonNull} many times throughout your code.
  *
- * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * <p>Conversely, {@link NullUnmarked} puts its enclosed code in null-unmarked context, the same as
+ * unannotated code. These annotations work as an inclusion-exclusion pair: of the annotations of
+ * <i>either</i> type on all enclosing elements (methods, classes, etc.), only the <i>nearest</i>
+ * (most narrowly enclosing) one is in effect.
+ *
+ * <p>For important information common to all four nullness annotations, see {@link
+ * org.jspecify.annotations}. To learn more about JSpecify, see <a
+ * href="https://jspecify.dev">jspecify.dev</a>.
  *
  * <h2 id="effects">Effects of being null-marked</h2>
  *
- * <p>Within null-marked code, as a <i>general</i> rule, a type usage is considered non-null (to
- * exclude {@code null} as a value) unless explicitly annotated as {@link Nullable}. However, there
- * are several special cases to address.
+ * <p>In null-marked context, a type usage is generally considered to be non-null unless explicitly
+ * annotated with {@link Nullable @Nullable}. However, there are a few special cases to address.
  *
  * <h3 id="effects-special-cases">Special cases</h3>
  *
- * <p>Within null-marked code:
+ * <p>Within null-marked context:
  *
  * <ul>
- *   <li>We might expect the type represented by a <b>wildcard</b> (like the {@code ?} in {@code
- *       List<?>}) to be non-null, but it isn't necessarily. It's non-null only if it {@code
- *       extends} a non-null type (like in {@code List<? extends String>}), or if the <i>class</i>
- *       in use accepts only non-null type arguments (such as if {@code List} were declared as
- *       {@code class List<E extends String>}). But if {@code List} does accept nullable type
- *       arguments, then the wildcards seen in {@code List<?>} and {@code List<? super String>} must
- *       include {@code null}, because they have no "upper bound". (<a
- *       href="https://bit.ly/3ppb8ZC">Why?</a>)
- *       <ul>
- *         <li>Conversely, a <b>type parameter</b> is always considered to have an upper bound; when
- *             none is given explicitly, {@code Object} is filled in by the compiler. The example
- *             {@code class MyList<E>} is interpreted identically to {@code class MyList<E extends
- *             Object>}: in both cases the type argument in {@code MyList<@Nullable Foo>} is
- *             out-of-bounds, so the list elements are always non-null. (<a
- *             href="https://bit.ly/3ppb8ZC">Why?</a>)
- *       </ul>
- *   <li>Otherwise, being null-marked has no consequence for any type usage where {@code @Nullable}
- *       and {@code @NonNull} are <a href="Nullable.html#applicability"><b>not applicable</b></a>,
- *       such as the root type of a local variable declaration.
- *   <li>When a type variable has a nullable upper bound, such as the {@code E} in {@code class
- *       Foo<E extends @Nullable Bar>}), an unannotated usage of this type variable is not
- *       considered nullable, non-null, or even of "unspecified" nullness. Rather it has
- *       <b>parametric nullness</b>. In order to support both nullable and non-null type arguments
- *       safely, the {@code E} type itself must be handled <i>strictly</i>: as if nullable when
- *       "read from", but as if non-null when "written to". (Contrast with {@code class Foo<E
- *       extends Bar>}, where usages of {@code E} are simply non-null, just like usages of {@code
- *       String} are.)
- *   <li>By using {@link NullUnmarked}, an element within null-marked code can be excluded and made
- *       null-unmarked, exactly as if there were no enclosing {@code @NullMarked} element at all.
+ *   <li>A <b>wildcard</b> (as seen in {@code List<?>}) generally represents a nullable type, unless
+ *       either it or its corresponding type parameter has a non-null upper bound. (<a
+ *       href="https://jspecify.dev/docs/nullness-design-faq/#wildcards-and-bounds">Why?</a>)
+ *   <li>A <b>type parameter</b> itself is a different case. It is never really "unbounded"; if no
+ *       upper bound is given explicitly, then {@code Object} is filled in by the compiler. This
+ *       means the example {@code class MyList<E>} is interpreted identically to {@code class
+ *       MyList<E extends Object>}, making the upper bound <i>non-null</i> {@code Object}. (<a
+ *       href="https://jspecify.dev/docs/nullness-design-faq/#type-parameters-and-bounds">Why?</a>)
+ *   <li>When a type parameter has a nullable upper bound, such as the {@code E} in {@code class
+ *       Foo<E extends @Nullable Bar>}, an unannotated usage of the associated <b>type variable</b>
+ *       (within that class) must be handled conservatively: it is nullable when read, yet cannot
+ *       have {@code null} assigned to it.
+ *   <li>Any type usage where {@code @Nullable} and {@code @NonNull} are {@linkplain
+ *       Nullable##applicability <b>not applicable</b>}, such as the root type in a local variable
+ *       declaration, is unaffected by being in null-marked context.
  * </ul>
  *
  * <h2 id="where">Where it can be used</h2>
  *
  * {@code @NullMarked} and {@link NullUnmarked @NullUnmarked} can be used on any package, class,
  * method, or constructor declaration; {@code @NullMarked} can be used on a module declaration as
- * well. Special considerations:
+ * well. ({@code @NullUnmarked} is not supported on modules, since it's already the default.)
+ * Special considerations:
  *
  * <ul>
- *   <li>To apply this annotation to an entire (single) <b>package</b>, create a <a
- *       href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-7.html#jls-7.4.1">{@code
- *       package-info.java}</a> file there. This is recommended so that newly-created classes will
- *       be null-marked by default. This annotation has no effect on "subpackages". <b>Warning</b>:
- *       if the package does not belong to a module, be very careful: it can easily happen that
- *       different versions of the package-info file are seen and used in different circumstances,
- *       causing the same classes to be interpreted inconsistently. For example, a package-info file
- *       from a {@code test} source path might hide the corresponding one from the {@code main}
- *       source path, or generated code might be compiled without seeing a package-info file at all.
- *   <li>Although Java permits it to be applied to a <b>record component</b> declaration (as in
- *       {@code record Foo(@NullMarked String bar) {...}}), this annotation has no meaning when used
- *       in that way.
- *   <li>Applying this annotation to an instance <b>method</b> of a <i>generic</i> class is
- *       acceptable, but is not recommended because it can lead to some confusing situations.
- *   <li>An advantage of Java <b>modules</b> is that you can make a lot of code null-marked with
- *       just a single annotation (before the {@code module} keyword). {@link NullUnmarked} is not
- *       supported on modules, since it's already the default.
+ *   <li>To apply these annotations to an entire (single) <b>package</b>, create a <a
+ *       href="https://docs.oracle.com/javase/specs/jls/se26/html/jls-7.html#jls-7.4.1">{@code
+ *       package-info.java}</a> file and annotate the package declaration there. This annotation has
+ *       no effect on "subpackages". <b>Warning</b>: if the package does not belong to a module, be
+ *       very careful: it can easily happen that different versions of the package-info file are
+ *       seen and used in different circumstances, causing the same classes to be interpreted
+ *       inconsistently.
+ *   <li>An advantage of Java <b>modules</b> is that you can put a lot of code in null-marked
+ *       context with just a single annotation (before the {@code module} keyword). <b>Warning</b>:
+ *       Even if you annotate the module for a library as {@code @NullMarked}, this has no effect
+ *       for users who place the library on the class path; it affects only those who place the
+ *       library on the <a href="https://openjdk.org/projects/jigsaw/quick-start">module path</a>,
+ *       which is less commonly used.
+ *   <li>Applying this annotation to an <b>annotation interface</b> does <i>not</i> express that
+ *       annotations of that type are synonymous with {@code @NullMarked}. It has the same meaning
+ *       as it does anywhere else.
  *   <li>If both {@code @NullMarked} and {@code @NullUnmarked} appear together on the same element,
  *       <i>neither</i> one is recognized.
  * </ul>

--- a/src/java.base/share/classes/org/jspecify/annotations/NullUnmarked.java
+++ b/src/java.base/share/classes/org/jspecify/annotations/NullUnmarked.java
@@ -27,55 +27,58 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated element and the code transitively {@linkplain
- * javax.lang.model.element.Element#getEnclosedElements() enclosed} within it is <b>null-unmarked
- * code</b>: there, type usages generally have <b>unspecified nullness</b> unless explicitly
- * annotated otherwise.
+ * javax.lang.model.element.Element#getEnclosedElements() enclosed} within it are in
+ * <b>null-unmarked context</b>: there, type usages generally have {@linkplain ##unspecified
+ * unspecified nullness} unless explicitly annotated otherwise.
  *
- * <p>This annotation's purpose is to ease migration of a large existing codebase to null-marked
- * status. It makes it possible to "flip the default" for new code added to a class or package even
- * before that class or package has been fully migrated. Since new code is the most important code
- * to analyze, this is strongly recommended as a temporary measure whenever necessary. However, once
- * a codebase has been fully migrated it would be appropriate to ban use of this annotation.
+ * <p>This annotation's purpose is to ease progressive migration of a large codebase. If some class
+ * or package can't be fully migrated yet, you can still make it {@linkplain NullMarked null-marked}
+ * by using this annotation on the portions that still need work. This practice is useful because it
+ * flips the default for <i>new</i> code added later, which is the most important code to analyze.
  *
- * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * <p>Once a codebase has been fully migrated it would be reasonable to ban use of this annotation.
  *
- * <h2>Null-marked and null-unmarked code</h2>
+ * <p>For important information common to all four nullness annotations, see {@link
+ * org.jspecify.annotations}. To learn more about JSpecify, see <a
+ * href="https://jspecify.dev">jspecify.dev</a>.
  *
- * <p>{@link NullMarked} and this annotation work as a pair to include and exclude sections of code
- * from null-marked status (respectively). Specifically, code is considered null-marked if the most
- * narrowly enclosing element annotated with either of these two annotations exists and is annotated
- * with {@code @NullMarked}.
+ * <h2>Null-marked and null-unmarked contexts</h2>
  *
- * <p>Otherwise it is considered null-unmarked. This can happen in two ways: either it is more
+ * <p>{@link NullMarked} puts enclosed code in null-marked context; this annotation puts it in
+ * null-unmarked context instead. These annotations work as an inclusion-exclusion pair: of the
+ * annotations of <i>either</i> type on all enclosing elements (methods, classes, etc.), only the
+ * <i>nearest</i> (most narrowly enclosing) one is in effect.
+ *
+ * <p>Otherwise, code is in null-unmarked context. This can happen in two ways: either it is more
  * narrowly enclosed by a {@code @NullUnmarked}-annotated element than by any
  * {@code @NullMarked}-annotated element, or neither annotation is present on any enclosing element.
  * No distinction is made between these cases.
  *
- * <p>The effects of being null-marked are described in the <a
- * href="NullMarked.html#effects">Effects</a> section of {@code NullMarked}.
+ * <p>The effects of being null-marked are described in the {@linkplain NullMarked##effects Effects}
+ * section of {@code NullMarked}.
  *
- * <h2>Unspecified nullness</h2>
+ * <h2 id="unspecified">Unspecified nullness</h2>
  *
- * <p>Within null-unmarked code, a type usage with no nullness annotation has <b>unspecified
- * nullness</b> (<a href="https://bit.ly/3ppb8ZC">Why?</a>). This means that, while there is always
- * <i>some</i> correct way to annotate it for nullness, that information is missing: we <i>do not
- * know</i> whether it includes or excludes {@code null} as a value. In such a case, tools can vary
- * widely in how strict or lenient their enforcement is, or might make it configurable.
+ * <p>Within null-unmarked context, a type usage that is {@linkplain Nullable##applicability
+ * nullness-applicable} but has no nullness annotation generally has <b>unspecified nullness</b> (<a
+ * href="https://jspecify.dev/docs/nullness-design-faq/#unspecified-nullness">Why?</a>). This means
+ * we <i>do not know</i> whether it includes or excludes {@code null} as a value. In such a case,
+ * tools can vary widely in how strict or lenient their enforcement is, or might even be
+ * configurable.
  *
  * <p>For more, please see this more <a
  * href="https://github.com/jspecify/jspecify/wiki/nullness-unspecified">comprehensive
  * discussion</a> of unspecified nullness.
  *
- * <p>There is no way for an individual type usage within null-marked code to have unspecified
- * nullness. (<a href="https://bit.ly/3ppb8ZC">Why?</a>)
+ * <p>There is no way for an individual type usage within null-marked context to have unspecified
+ * nullness. (<a
+ * href="https://jspecify.dev/docs/nullness-design-faq/#type-use-unspecified-nullness">Why?</a>)
  *
  * <h2>Where it can be used</h2>
  *
- * The information in the <a href="NullMarked.html#where">Where it can be used</a> section of {@code
+ * The information in the {@linkplain NullMarked##where Where it can be used} section of {@code
  * NullMarked} applies as well to this annotation.
  */
-// TODO(kevinb9n): word the middle section better with good words
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({PACKAGE, TYPE, METHOD, CONSTRUCTOR})

--- a/src/java.base/share/classes/org/jspecify/annotations/Nullable.java
+++ b/src/java.base/share/classes/org/jspecify/annotations/Nullable.java
@@ -36,104 +36,111 @@ import java.lang.annotation.Target;
  *
  * void setField(@Nullable String value) { field = value; }
  *
- * List<@Nullable String> getList() { ... }
+ * List<@Nullable String> getList() { … }
  * }</pre>
  *
- * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * <p>For important information common to all four nullness annotations, see {@link
+ * org.jspecify.annotations}. To learn more about JSpecify, see <a
+ * href="https://jspecify.dev">jspecify.dev</a>.
  *
- * <h2>Meaning per each kind of type usage</h2>
+ * <h2>Meaning for each kind of type usage</h2>
  *
- * <p>The essential meaning of this annotation is always the same: the type it annotates is
- * considered to include {@code null} as a value. But this may affect your code a little differently
- * based on the kind of type usage involved.
+ * <p>Despite the itemized list here, the essential meaning of this annotation is always the same in
+ * every case: the type it annotates is considered to include {@code null} as a value. A good way to
+ * read {@code @Nullable String} in any context is <b>"string-or-null"</b>. That's usually all you
+ * need to think about, but this section offers some additional explanation for each kind of
+ * context.
  *
  * <ul>
- *   <li>On a <b>parameter type</b>: The {@code setField} method (at top) permissively accepts a
- *       "string-or-null", meaning that it is okay to pass an actual string, or to pass {@code
- *       null}. (This doesn't guarantee that passing {@code null} won't produce an exception at
- *       runtime, but it should be much less likely.) This also applies to the type of a lambda
- *       expression parameter, if that type is given explicitly (otherwise its nullness must be
- *       inferred from context).
- *   <li>On a <b>method return type</b>: The {@code getField} method returns a "string-or-null", so
- *       while the caller might get a string back, it should also address the possibility of getting
- *       {@code null} instead. (This doesn't guarantee there is any circumstance in which {@code
- *       null} <i>will</i> actually be returned.)
- *   <li>On a <b>field type</b>: The {@code field} field has the type "string-or-null", so at times
- *       it might hold a string, and at times it might hold {@code null}. (Of course, every field of
- *       a reference type <i>originally</i> holds {@code null}, but as long as the class ensures
- *       that its uninitialized states can't be observed, it's appropriate to overlook that fact.)
- *   <li>On a <b>type argument</b>: A type usage of "nullable string" appears <i>within</i> the
- *       compound type {@code List<@Nullable String>}. No matter how this type is used (return type,
- *       etc.), this means the same thing: every appearance of {@code E} in {@code List}'s member
- *       signatures will be considered nullable. For a list, this means it may contain null
- *       <i>elements</i>. If the list reference itself might be null as well, we can write
- *       {@code @Nullable List<@Nullable String>}, a "nullable list of nullable strings".
- *   <li>On the upper bound of a <b>type parameter</b>: For example, as seen in {@code class List<E
- *       extends @Nullable Object>}. This means that a <i>type argument</i> supplied for that type
- *       parameter is permitted to be nullable if desired: {@code List<@Nullable String>}. (A
- *       non-null type argument, as in {@code List<String>}, is permitted either way.)
- *   <li>On a usage of a <b>type variable</b>: A type parameter, like the {@code E} in {@code
- *       interface List<E>}, defines a "type variable" of the same name, usable only <i>within</i>
- *       the scope of the declaring API element. In any example using {@code String} above, a type
- *       variable like {@code E} might appear instead. {@code @Nullable} continues to mean "or null"
- *       as always, but notably, this works without regard to whether the type argument is
- *       <i>already</i> nullable. For example, suppose that {@code class Foo<E extends @Nullable
- *       Object>} has a method {@code @Nullable E eOrNull()}. Then, whether {@code foo} is of type
- *       {@code Foo<String>} or {@code Foo<@Nullable String>}, the expression {@code foo.eOrNull()}
- *       is nullable either way. Using {@code @Nullable E} in this way is called "nullable
- *       projection" (<a href="NonNull.html#projection">non-null projection</a> is likewise
- *       supported, but less commonly useful).
+ *   <li>On a <b>parameter type</b>: See the {@code setField} example above. It permissively accepts
+ *       a "string-or-null", meaning that it is okay to pass an actual string, or to pass {@code
+ *       null}. (This does not guarantee that passing {@code null} won't produce an exception at
+ *       runtime. <a
+ *       href="https://jspecify.dev/docs/nullness-design-faq/#runtime-guarantees">Why?</a>) Lambda
+ *       expression parameters work in the same way <i>if</i> their types are written explicitly.
+ *   <li>On a <b>method return type</b>: See the {@code getField} example above. It returns a
+ *       "string-or-null", so while the caller might get a real string back, it might get {@code
+ *       null} as well, and should be prepared for that possibility.
+ *   <li>On a <b>field type</b>: See the {@code field} example above. It has the type
+ *       "string-or-null", so it might hold a string and it might hold {@code null}. (If you are
+ *       confident the containing object can't be observed in its uninitialized state, the field
+ *       need not be annotated solely because it is null during initialization.)
+ *   <li>On a <b>type argument</b>: Within the compound type {@code MyList<@Nullable String>}, we
+ *       can see a usage of the type "string-or-null". To understand what {@code @Nullable} means
+ *       here, read the {@code MyList<E>} API; every appearance you see of the {@code E} type will
+ *       be treated as nullable (unless it has its own nullness annotation, which takes precedence).
+ *       For a typical container type like this example, this means it can contain null
+ *       <i>elements</i>; if your list itself might be null as well, we can write {@code @Nullable
+ *       MyList<@Nullable String>}: a nullable list of nullable strings.
+ *   <li>On the upper bound of a <b>type parameter</b>: For example, consider {@code interface
+ *       List<E extends @Nullable String>}. This means that type arguments in that position
+ *       <i>may</i> be nullable (as in {@code List<@Nullable String>}). A non-null type argument, as
+ *       in {@code List<String>}, is permitted either way.
+ *   <li><span id="projection">On a usage of a <b>type variable</b>:</span> A type parameter, like
+ *       the {@code T} declared in {@code class Optional<T>}, introduces a <i>type variable</i> of
+ *       the same name, usable only within the scope of the declaring API element. All the preceding
+ *       examples using {@code String} are equally valid for a type variable like {@code E}.
+ *       {@code @Nullable} continues to mean "or null" as always, regardless of whether the type
+ *       argument "already" includes {@code null}. For example, suppose that {@code class Foo<E
+ *       extends @Nullable Object>} has a method {@code @Nullable E eOrNull()}. Then, whether a
+ *       variable {@code foo} is of type {@code Foo<String>} or {@code Foo<@Nullable String>}, the
+ *       expression {@code foo.eOrNull()} is nullable either way. Using {@code @Nullable E} in this
+ *       way is called <i>nullable projection</i>.
+ *   <li>On an <b>array type</b>: The nullness of the array and of its components can each be
+ *       indicated separately. For example, in {@linkplain NullMarked null-marked} context,
+ *       {@code @Nullable String[]} is a non-null array of nullable strings, and {@code
+ *       String @Nullable []} is a nullable array of non-null strings.
+ *   <li>On a <b>varargs parameter</b>: Use {@code @Nullable String...} to indicate that the
+ *       individual strings may be null. To let {@code null} be passed as the entire array, use
+ *       {@code String @Nullable ...}.
  *   <li>On a <b>nested type</b>: In most examples above, in place of {@code String} we might use a
  *       nested type such as {@code Map.Entry}. The Java syntax for annotating such a type as
  *       nullable looks like {@code Map.@Nullable Entry}.
- *   <li>On a <b>record component</b>: As expected, {@code @Nullable} here applies equally to the
- *       corresponding parameter type of the canonical constructor, and to the return type of a
- *       generated accessor method as well. If an explicit accessor method is provided for this
- *       record component, it must still be annotated explicitly. Any non-null components should be
- *       checked (for example using {@link java.util.Objects#requireNonNull}) in a <a
- *       href="https://docs.oracle.com/en/java/javase/19/language/records.html">compact
- *       constructor</a>.
+ *   <li>On a <b>record component</b>: Java propagates all type-use annotations (including
+ *       {@code @Nullable}) from a record component type to the type of the generated field,
+ *       accessor method, and/or constructor parameter. If the constructor parameter list or
+ *       accessor method is provided explicitly, it must still be annotated explicitly.
  * </ul>
  *
- * <h2 id="applicability">Where it is applicable</h2>
+ * <h2 id="applicability">Where it is not applicable</h2>
  *
  * <p>This annotation and {@link NonNull} are applicable to any <a
  * href="https://github.com/jspecify/jspecify/wiki/type-usages">type usage</a> <b>except</b> the
- * following cases, where they have no defined meaning:
+ * following cases, where they have no defined meaning and should not be used:
  *
  * <ul>
- *   <li>On any<b> intrinsically non-null type usage</b>. Some type usages are incapable of
- *       including {@code null} by the rules of the Java language. Examples include any usage of a
- *       primitive type, the root type of the argument to {@code instanceof}, a method return type
- *       in an annotation interface, or the type following {@code throws} or {@code catch}. In such
- *       locations, a nullness annotation could only be contradictory ({@code @Nullable}) or
- *       redundant ({@code @NonNull}).
- *   <li>On the root type of a <b>local variable</b> declaration. The nullness of a local variable
- *       itself is not a fixed declarative property of its <i>type</i>. Rather it should be inferred
- *       from the nullness of each expression assigned to the variable, possibly changing over time.
- *       (<a href="https://bit.ly/3ppb8ZC">Why?</a>). Subcomponents of the type (type arguments,
- *       array component types) are annotatable as usual.
- *   <li>On the root type in a <b>cast expression</b>. To inform an analyzer that an expression it
+ *   <li>On any <b>intrinsically non-null type usage</b>: one that is incapable of including {@code
+ *       null} by the rules of the Java language, like the type following {@code throws}. A nullness
+ *       annotation in this location could only be either contradictory or redundant.
+ *   <li>On a <b>local variable</b> declaration (root type only). While the cases listed above
+ *       benefit from <i>declarative</i> nullness, the nullness of a local variable is more properly
+ *       determined through flow analysis (<a
+ *       href="https://jspecify.dev/docs/nullness-design-faq/#local-variables">Why?</a>). This rule
+ *       applies only to the <i>root type</i> of the variable; type components, such as type
+ *       arguments, follow the usual rules.
+ *   <li>In a <b>cast expression</b> (root type only). To inform an analyzer that an expression it
  *       sees as nullable is truly non-null, use an assertion or a method like {@link
- *       java.util.Objects#requireNonNull}. (<a href="https://bit.ly/3ppb8ZC">Why?</a>)
- *       Subcomponents of the type (type arguments, array component types) are annotatable as usual.
+ *       java.util.Objects#requireNonNull}. (<a
+ *       href="https://jspecify.dev/docs/nullness-design-faq/#casts">Why?</a>) Type components, such
+ *       as type arguments, follow the usual rules.
  *   <li>On any part of the argument to <b>{@code instanceof}</b>. The root type is intrinsically
  *       non-null, as discussed above, and nothing else about nullness is checked at runtime.
  *   <li>On any part of a <b>receiver parameter</b> type (<a
- *       href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-8.html#jls-8.4">JLS 8.4</a>).
+ *       href="https://docs.oracle.com/javase/specs/jls/se26/html/jls-8.html#jls-8.4">JLS 8.4</a>).
  *   <li>If both {@code @Nullable} and {@code @NonNull} appear on the same type usage,
  *       <i>neither</i> one is recognized.
  * </ul>
  *
- * Whether the code is {@link NullMarked} also has no consequence in the above locations.
+ * Whether the surrounding code is in null-marked context also has no consequence in the above
+ * locations.
  *
  * <h2>Unannotated type usages</h2>
  *
- * <p>For a type usage where nullness annotations are <a href="#applicability">applicable</a> but
- * not present, its nullness depends on whether it appears within {@linkplain NullMarked
- * null-marked} code; see that class for details. Note in particular that nullness information from
- * a superclass is never automatically "inherited".
+ * <p>For a type usage where nullness annotations are {@linkplain ##applicability applicable} but
+ * not present, its nullness depends on whether it appears within null-marked context; see {@link
+ * NullMarked} for details. Note in particular that nullness information from a superclass is never
+ * automatically "inherited." (<a
+ * href="https://jspecify.dev/docs/nullness-design-faq/#nullable-equals">Why?</a>)
  */
 @Documented
 @Target(TYPE_USE)

--- a/src/java.base/share/classes/org/jspecify/annotations/package-info.java
+++ b/src/java.base/share/classes/org/jspecify/annotations/package-info.java
@@ -15,23 +15,25 @@
  */
 
 /**
- * JSpecify annotations. See <a href="http://jspecify.org">jspecify.org</a> for general information.
+ * JSpecify annotations. See <a href="https://jspecify.dev">jspecify.dev</a> for general
+ * information.
  *
  * <h2>What's here?</h2>
  *
- * This package will contain annotations supporting a variety of static analyses. For now it
- * supports just nullness analysis.
+ * This package contains annotations supporting nullness analysis; in the future it might cover
+ * other kinds of static analysis as well.
  *
  * <h3 id="nullness">Nullness</h3>
  *
  * The primary annotations of interest are {@link NullMarked} and {@link Nullable}. Together they
- * provide <b>declarative, use-site nullness</b> for Java types. Less frequently, their negations
- * may be useful: {@link NullUnmarked} and {@link NonNull}, respectively.
- *
- * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * provide <b>declarative, use-site nullness</b> for Java type usages. Less frequently, their
+ * negations may be useful: {@link NullUnmarked} and {@link NonNull}, respectively.
  *
  * <h2 id="tool-behavior">Note on tool behavior</h2>
+ *
+ * <p>The presence of these annotations in your code has well-defined semantic meaning, but no
+ * <i>direct</i> consequences. It is up to your adopted tools and libraries to voluntarily read and
+ * act on the information they provide.
  *
  * <p>Each of these annotations defines a single meaning shared by all compatible tools (and
  * libraries). JSpecify documentation aims to provide unambiguous, tool-independent answers for how


### PR DESCRIPTION
This should make no difference, since [the changes of 1.0.1](https://github.com/jspecify/jspecify/releases/tag/v1.0.1) are all about build setup and documentation. But it seems like a good habit to get into during a release (or perhaps even before one).
