### PR TITLE
Address `zizmor` findings:

### DIFF
--- a/.github/workflows/jspecify.yml
+++ b/.github/workflows/jspecify.yml
@@ -14,9 +14,11 @@ jobs:
     env:
       JAVA_VERSION: 24
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      with:
+        persist-credentials: false
     - name: Set up JDK 24
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
       with:
         java-version: 24
         distribution: 'temurin'

--- a/.github/workflows/jspecify.yml
+++ b/.github/workflows/jspecify.yml
@@ -14,11 +14,11 @@ jobs:
     env:
       JAVA_VERSION: 24
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up JDK 24
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: 24
         distribution: 'temurin'


### PR DESCRIPTION
- [`persist-credentials: false`](https://docs.zizmor.sh/audits/#artipacked)
- [pinning `uses`](https://docs.zizmor.sh/audits/#unpinned-uses)

I've focused only on our custom CI configuration, not on the CI configuration from upstream: I'm not even sure whether we run the upstream configuration, and even if we do, I'd prefer not to introduce changes (fairly invasive ones in some cases!) that might lead to merge conflicts. Ideally we'd do better someday, including trying to make changes upstream.
