### PR TITLE
Annotate a few exceptions.

### DIFF
--- a/src/java.base/share/classes/java/io/UnsupportedEncodingException.java
+++ b/src/java.base/share/classes/java/io/UnsupportedEncodingException.java
@@ -24,12 +24,16 @@
  */
 package java.io;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * The Character Encoding is not supported.
  *
  * @author  Asmus Freytag
  * @since   1.1
  */
+@NullMarked
 public class UnsupportedEncodingException
     extends IOException
 {
@@ -47,7 +51,7 @@ public class UnsupportedEncodingException
      * Constructs an UnsupportedEncodingException with a detail message.
      * @param s Describes the reason for the exception.
      */
-    public UnsupportedEncodingException(String s) {
+    public UnsupportedEncodingException(@Nullable String s) {
         super(s);
     }
 }

--- a/src/java.base/share/classes/java/lang/MatchException.java
+++ b/src/java.base/share/classes/java/lang/MatchException.java
@@ -25,6 +25,9 @@
 
 package java.lang;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
  * Thrown to indicate an unexpected failure in pattern matching.
  *
@@ -76,6 +79,7 @@ package java.lang;
  *
  * @since 21
  */
+@NullMarked
 public final class MatchException extends RuntimeException {
     @java.io.Serial
     private static final long serialVersionUID = 0L;
@@ -91,7 +95,7 @@ public final class MatchException extends RuntimeException {
      *         permitted, and indicates that the cause is nonexistent or
      *         unknown.)
      */
-    public MatchException(String message, Throwable cause) {
+    public MatchException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
+++ b/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
@@ -25,6 +25,7 @@
 
 package java.nio.charset;
 
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Checked exception thrown when an input byte sequence is not legal for given
@@ -33,7 +34,7 @@ package java.nio.charset;
  *
  * @since 1.4
  */
-
+@NullMarked
 public class MalformedInputException
     extends CharacterCodingException
 {

--- a/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
+++ b/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
@@ -25,6 +25,7 @@
 
 package java.nio.charset;
 
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Checked exception thrown when an input character (or byte) sequence
@@ -33,7 +34,7 @@ package java.nio.charset;
  *
  * @since 1.4
  */
-
+@NullMarked
 public class UnmappableCharacterException
     extends CharacterCodingException
 {


### PR DESCRIPTION
A couple notes:

- `UnsupportedEncodingException`: I didn't look much to see how likely a null argument was. But given that the class provides a no-arg constructor, which results in a null message, I saw no particular reason to restrict callers from passing a null message to the one-arg constructor, especially when most exception types support that.

- `MatchException`: The docs are clearer about allowing a null _cause_, but `javac` does [generate calls that pass `null` for both the cause and the message](https://github.com/openjdk/jdk/blob/5121008600e61fc931c486504aad4fecbd46f587/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java#L3835).

- I ignored `CoderMalfunctionError` because I was uncertain whether to give it a nullable cause or not.

  - I generally err on the side of nullable, as in `UnsupportedEncodingException` above.

  - I see one test in Google's codebase that passes `null`, but doesn't care what it passes, and it could easily be changed not to pass somethign else.

  - I see a test in some version of Apache Harmony that passes `null` and verifies that it works.

  - But "clearly" it's "supposed" to have a non-null cause, similar to a type like `InvocationTargetException` or (possibly to a lesser extent, sadly) `ExecutionException`. For discussion of those types, see https://github.com/jspecify/jspecify/issues/490.

(prompted by https://github.com/google/xplat/commit/7ab1a2c5b64d57086a7d5050de3f517b4ffb8283)
