### PR TITLE
Annotate `CoderResult` and `CodingErrorAction`.

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/CoderResult.java
+++ b/src/java.base/share/classes/java/nio/charset/CoderResult.java
@@ -29,6 +29,7 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A description of the result state of a coder.
@@ -80,7 +81,7 @@ import java.util.Map;
  * @author JSR-51 Expert Group
  * @since 1.4
  */
-
+@NullMarked
 public final class CoderResult {
 
     private static final int CR_UNDERFLOW  = 0;

--- a/src/java.base/share/classes/java/nio/charset/CodingErrorAction.java
+++ b/src/java.base/share/classes/java/nio/charset/CodingErrorAction.java
@@ -25,6 +25,7 @@
 
 package java.nio.charset;
 
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A typesafe enumeration for coding-error actions.
@@ -39,7 +40,7 @@ package java.nio.charset;
  * @author JSR-51 Expert Group
  * @since 1.4
  */
-
+@NullMarked
 public final class CodingErrorAction {
 
     private String name;


### PR DESCRIPTION
(prompted by https://github.com/google/xplat/commit/7ab1a2c5b64d57086a7d5050de3f517b4ffb8283)
