### PR TITLE
Set up Dependabot but for `jspecify.yml` CI only.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   groups:
     dependencies:
       applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    dependencies:
+      applies-to: version-updates
+      patterns:
+        - "*"
+  exclude-paths:
+    - ".github/workflows/build-alpine-linux.yml"
+    - ".github/workflows/build-cross-compile.yml"
+    - ".github/workflows/build-linux.yml"
+    - ".github/workflows/build-macos.yml"
+    - ".github/workflows/build-windows.yml"
+    - ".github/workflows/main.yml"
+    - ".github/workflows/test.yml"


### PR DESCRIPTION
This would have saved us some effort in https://github.com/jspecify/jdk/pull/149.
